### PR TITLE
[R1378] experiment with document context switch

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/model/Vocabulary.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/Vocabulary.java
@@ -43,7 +43,7 @@ public class Vocabulary extends Asset<String> implements Serializable {
     @OWLAnnotationProperty(iri = DC.Terms.DESCRIPTION)
     private String description;
 
-    @OWLObjectProperty(iri = cz.cvut.kbss.termit.util.Vocabulary.s_p_popisuje_dokument, cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+    @OWLObjectProperty(iri = cz.cvut.kbss.termit.util.Vocabulary.s_p_popisuje_dokument, cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.EAGER)
     private Document document;
 
     @ParticipationConstraints(nonEmpty = true)

--- a/src/main/java/cz/cvut/kbss/termit/model/Vocabulary.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/Vocabulary.java
@@ -43,7 +43,7 @@ public class Vocabulary extends Asset<String> implements Serializable {
     @OWLAnnotationProperty(iri = DC.Terms.DESCRIPTION)
     private String description;
 
-    @OWLObjectProperty(iri = cz.cvut.kbss.termit.util.Vocabulary.s_p_popisuje_dokument, cascade = { CascadeType.PERSIST, CascadeType.MERGE }, fetch = FetchType.EAGER)
+    @OWLObjectProperty(iri = cz.cvut.kbss.termit.util.Vocabulary.s_p_popisuje_dokument, cascade = { CascadeType.PERSIST }, fetch = FetchType.EAGER)
     private Document document;
 
     @ParticipationConstraints(nonEmpty = true)

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/ResourceDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/ResourceDao.java
@@ -115,6 +115,17 @@ public class ResourceDao extends AssetDao<Resource> implements SupportsLastModif
         }
     }
 
+    @ModifiesData
+    @Override
+    public void remove(Resource entity) {
+        super.remove(entity);
+        URI context = null;
+        if (entity instanceof Document) {
+            context = em.find(Document.class, entity.getUri()).getVocabulary();
+        }
+        em.getEntityManagerFactory().getCache().evict(type, entity.getUri(), context);
+    }
+
     private URI resolveVocabularyId(Resource resource) {
         if (resource instanceof Document) {
             return ((Document) resource).getVocabulary();

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/ResourceDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/ResourceDao.java
@@ -115,17 +115,6 @@ public class ResourceDao extends AssetDao<Resource> implements SupportsLastModif
         }
     }
 
-    @ModifiesData
-    @Override
-    public void remove(Resource entity) {
-        super.remove(entity);
-        URI context = null;
-        if (entity instanceof Document) {
-            context = em.find(Document.class, entity.getUri()).getVocabulary();
-        }
-        em.getEntityManagerFactory().getCache().evict(type, entity.getUri(), context);
-    }
-
     private URI resolveVocabularyId(Resource resource) {
         if (resource instanceof Document) {
             return ((Document) resource).getVocabulary();
@@ -246,5 +235,26 @@ public class ResourceDao extends AssetDao<Resource> implements SupportsLastModif
     @EventListener
     public void refreshLastModified(RefreshLastModifiedEvent event) {
         refreshLastModified();
+    }
+
+    /**
+     * Removes a document from the context (given by the document instance descriptor)
+     * and flushes the entity manager.
+     *
+     * @param document document
+     */
+    public void removeDocumentFromContext(final Document document) {
+        this.remove(document);
+        this.em.flush();
+    }
+
+    /**
+     * Adds a document to the context givent by the vocabulary IRI.
+     *
+     * @param document document
+     * @param vocabularyId URI of the vocabulary context
+     */
+    public void persistDocumentToVocabularyContext(final Document document, final URI vocabularyId) {
+        em.persist(document,descriptorFactory.vocabularyDescriptor(vocabularyId));
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -19,7 +19,6 @@ import cz.cvut.kbss.termit.dto.assignment.ResourceTermAssignments;
 import cz.cvut.kbss.termit.event.FileRenameEvent;
 import cz.cvut.kbss.termit.exception.InvalidParameterException;
 import cz.cvut.kbss.termit.exception.NotFoundException;
-import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.exception.UnsupportedAssetOperationException;
 import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.TextAnalysisRecord;

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -181,7 +181,7 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
         final Document dOriginal = vOriginal.getDocument();
         final Document document = vNew.getDocument();
 
-        if ( dOriginal == document || ( dOriginal != null && dOriginal.equals(document) ) ) {
+        if (Objects.equals(dOriginal, document)) {
             return;
         }
 

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -179,6 +179,12 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
      */
     public void rewireDocumentsOnVocabularyUpdate(final Vocabulary vOriginal, final Vocabulary vNew) {
         final Document dOriginal = vOriginal.getDocument();
+        final Document document = vNew.getDocument();
+
+        if ( dOriginal == document || dOriginal.equals(document) ) {
+            return;
+        }
+
         if ( dOriginal != null ) {
             // remove from vocabulary ctx
             resourceDao.removeDocumentFromContext(dOriginal);
@@ -186,7 +192,6 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
             persist(dOriginal);
         }
 
-        final Document document = vNew.getDocument();
         if (document != null) {
             Document dNew = (Document) getRequiredReference(document.getUri());
             // remove from default ctx

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -181,7 +181,7 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
         final Document dOriginal = vOriginal.getDocument();
         final Document document = vNew.getDocument();
 
-        if ( dOriginal == document || dOriginal.equals(document) ) {
+        if ( dOriginal == document || ( dOriginal != null && dOriginal.equals(document) ) ) {
             return;
         }
 

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -170,6 +170,13 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
         return resourceDao.getLastModified();
     }
 
+    /**
+     * Moves the triples of the document from the original vocabulary to the default context and from the
+     * new vocabulary to the context of this vocabulary.
+     *
+     * @param vOriginal original version of the vocabulary (before update)
+     * @param vNew new version of the vocabulary (after update)
+     */
     public void rewireDocumentsOnVocabularyUpdate(final Vocabulary vOriginal, final Vocabulary vNew) {
         final Document dOriginal = vOriginal.getDocument();
         if ( dOriginal != null ) {

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -1,17 +1,18 @@
 /**
  * TermIt Copyright (C) 2019 Czech Technical University in Prague
  * <p>
- * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
- * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
- * version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  * <p>
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
- * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
  * <p>
- * You should have received a copy of the GNU General Public License along with this program.  If not, see
- * <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with this program.  If
+ * not, see <https://www.gnu.org/licenses/>.
  */
+
 package cz.cvut.kbss.termit.service.repository;
 
 import cz.cvut.kbss.termit.asset.provenance.SupportsLastModification;
@@ -41,7 +42,7 @@ import java.util.Objects;
 
 @Service
 public class ResourceRepositoryService extends BaseAssetRepositoryService<Resource>
-        implements SupportsLastModification {
+    implements SupportsLastModification {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResourceRepositoryService.class);
 
@@ -73,7 +74,8 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
     protected void prePersist(Resource instance) {
         super.prePersist(instance);
         if (instance.getUri() == null) {
-            instance.setUri(idResolver.generateIdentifier(ConfigParam.NAMESPACE_RESOURCE, instance.getLabel()));
+            instance.setUri(
+                idResolver.generateIdentifier(ConfigParam.NAMESPACE_RESOURCE, instance.getLabel()));
         }
         verifyIdentifierUnique(instance);
     }
@@ -83,7 +85,8 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
      *
      * @param resource   Resource to persist
      * @param vocabulary Vocabulary context
-     * @throws IllegalArgumentException If the specified Resource is neither a {@code Document} nor a {@code File}
+     * @throws IllegalArgumentException If the specified Resource is neither a {@code Document}
+     * nor a {@code File}
      */
     @Transactional
     public void persist(Resource resource, Vocabulary vocabulary) {
@@ -118,9 +121,12 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
     /**
      * Gets aggregated information about Terms assigned to the specified Resource.
      * <p>
-     * Since retrieving all the assignments and occurrences related to the specified Resource may be time consuming and
-     * is rarely required, this method provides aggregate information in that the returned instances contain only
-     * distinct Terms assigned to/occurring in a Resource together with information about how many times they occur and
+     * Since retrieving all the assignments and occurrences related to the specified Resource may
+     * be time consuming and
+     * is rarely required, this method provides aggregate information in that the returned
+     * instances contain only
+     * distinct Terms assigned to/occurring in a Resource together with information about how
+     * many times they occur and
      * whether they are suggested or asserted.
      *
      * @param resource Resource to get assignment info for
@@ -143,7 +149,8 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
 
     @Override
     protected void preRemove(Resource instance) {
-        LOG.trace("Removing term occurrences in resource {} which is about to be removed.", instance);
+        LOG.trace("Removing term occurrences in resource {} which is about to be removed.",
+            instance);
         termOccurrenceDao.removeAll(instance);
         assignmentService.removeAll(instance);
         removeFromParentDocumentIfFile(instance);
@@ -171,34 +178,31 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
     }
 
     /**
-     * Moves the triples of the document from the original vocabulary to the default context and from the
+     * Moves the triples of the document from the original vocabulary to the default context and
+     * from the
      * new vocabulary to the context of this vocabulary.
      *
      * @param vOriginal original version of the vocabulary (before update)
      * @param vNew new version of the vocabulary (after update)
      */
-    public void rewireDocumentsOnVocabularyUpdate(final Vocabulary vOriginal, final Vocabulary vNew) {
+    public void rewireDocumentsOnVocabularyUpdate(final Vocabulary vOriginal,
+                                                  final Vocabulary vNew) {
         final Document dOriginal = vOriginal.getDocument();
-        final Document document = vNew.getDocument();
+        final Document dNew = vNew.getDocument();
 
-        if (Objects.equals(dOriginal, document)) {
+        if (Objects.equals(dOriginal, dNew)) {
             return;
         }
 
-        if ( dOriginal != null ) {
-            // remove from vocabulary ctx
-            resourceDao.removeDocumentFromContext(dOriginal);
-            // add to default ctx
-            persist(dOriginal);
+        if (dOriginal != null) {
+            // rewire to default ctx
+            resourceDao.updateDocumentForVocabulary(dOriginal, dOriginal, null);
         }
 
-        if (document != null) {
-            Document dNew = (Document) getRequiredReference(document.getUri());
-            // remove from default ctx
-            resourceDao.removeDocumentFromContext(dNew);
-            document.setVocabulary(null);
-            // add to vocabulary context
-            resourceDao.persistDocumentToVocabularyContext(document,vNew.getUri());
+        if (dNew != null) {
+            final Document dNewManaged = (Document) getRequiredReference(dNew.getUri());
+            // rewire to vocabulary ctx
+            resourceDao.updateDocumentForVocabulary(dNewManaged, dNew, vNew.getUri());
         }
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -169,4 +169,24 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
     public long getLastModified() {
         return resourceDao.getLastModified();
     }
+
+    public void rewireDocumentsOnVocabularyUpdate(final Vocabulary vOriginal, final Vocabulary vNew) {
+        final Document dOriginal = vOriginal.getDocument();
+        if ( dOriginal != null ) {
+            // remove from vocabulary ctx
+            resourceDao.removeDocumentFromContext(dOriginal);
+            // add to default ctx
+            persist(dOriginal);
+        }
+
+        final Document document = vNew.getDocument();
+        if (document != null) {
+            Document dNew = (Document) getRequiredReference(document.getUri());
+            // remove from default ctx
+            resourceDao.removeDocumentFromContext(dNew);
+            document.setVocabulary(null);
+            // add to vocabulary context
+            resourceDao.persistDocumentToVocabularyContext(document,vNew.getUri());
+        }
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -4,8 +4,6 @@ import cz.cvut.kbss.termit.exception.VocabularyImportException;
 import cz.cvut.kbss.termit.exception.VocabularyRemovalException;
 import cz.cvut.kbss.termit.model.*;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
-import cz.cvut.kbss.termit.model.resource.Document;
-import cz.cvut.kbss.termit.model.resource.Resource;
 import cz.cvut.kbss.termit.model.validation.ValidationResult;
 import cz.cvut.kbss.termit.persistence.dao.AssetDao;
 import cz.cvut.kbss.termit.persistence.dao.VocabularyDao;
@@ -84,23 +82,11 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
 
     @Override
     @Transactional
-    public Vocabulary update(Vocabulary instance) {
-        final Vocabulary vOriginal =  super.findRequired(instance.getUri());
-        final Document dOriginal = vOriginal.getDocument();
-        if ( dOriginal != null ) {
-            resourceService.remove(dOriginal);
-            Optional<Resource> d2 = resourceService.find(dOriginal.getUri());
-            System.out.println(d2.isPresent());
-            resourceService.persist(dOriginal);
-        }
-
-        final Document document = instance.getDocument();
-        if (document != null) {
-            Document dNew = (Document) resourceService.findRequired(document.getUri());
-            resourceService.remove(dNew);
-        }
-        super.update(instance);
-        return instance;
+    public Vocabulary update(Vocabulary vNew) {
+        final Vocabulary vOriginal = super.findRequired(vNew.getUri());
+        resourceService.rewireDocumentsOnVocabularyUpdate(vOriginal, vNew);
+        super.update(vNew);
+        return vNew;
     }
 
     /**

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryServiceTest.java
@@ -391,11 +391,10 @@ class ResourceRepositoryServiceTest extends BaseServiceTestRunner {
     @Test
     void rewireDocumentsOnVocabularyUpdatePutsUpdatedDocumentIntoVocabularyContext() {
         final cz.cvut.kbss.termit.model.Vocabulary vOriginal = Generator.generateVocabularyWithId();
-        final Document document = Generator.generateDocumentWithId();
         vOriginal.setDocument(null);
 
         final Descriptor d = descriptorFactory.vocabularyDescriptor(vOriginal);
-
+        final Document document = Generator.generateDocumentWithId();
         transactional(() -> {
             em.persist(vOriginal, d);
             em.persist(document);

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryServiceTest.java
@@ -15,6 +15,7 @@
 package cz.cvut.kbss.termit.service.repository;
 
 import cz.cvut.kbss.jopa.model.EntityManager;
+import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.termit.dto.assignment.ResourceTermAssignments;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
@@ -364,5 +365,50 @@ class ResourceRepositoryServiceTest extends BaseServiceTestRunner {
         final long result = sut.getLastModified();
         assertThat(result, greaterThan(0L));
         assertThat(result, lessThanOrEqualTo(System.currentTimeMillis()));
+    }
+
+    @Test
+    void rewireDocumentsOnVocabularyUpdatePutsOriginalDocumentIntoDefaultContext() {
+        final cz.cvut.kbss.termit.model.Vocabulary vOriginal = Generator.generateVocabularyWithId();
+        final Document document = Generator.generateDocumentWithId();
+        vOriginal.setDocument(document);
+
+        final Descriptor d = descriptorFactory.vocabularyDescriptor(vOriginal);
+
+        transactional(() -> { em.persist(vOriginal, d); });
+
+        final cz.cvut.kbss.termit.model.Vocabulary vUpdate = new cz.cvut.kbss.termit.model.Vocabulary();
+        vUpdate.setUri(vOriginal.getUri());
+        vUpdate.setDocument(null);
+
+        transactional(() -> {
+            sut.rewireDocumentsOnVocabularyUpdate(vOriginal, vUpdate);
+        });
+
+        assertThat(em.find( Document.class, document.getUri(), d ), nullValue());
+    }
+
+    @Test
+    void rewireDocumentsOnVocabularyUpdatePutsUpdatedDocumentIntoVocabularyContext() {
+        final cz.cvut.kbss.termit.model.Vocabulary vOriginal = Generator.generateVocabularyWithId();
+        final Document document = Generator.generateDocumentWithId();
+        vOriginal.setDocument(null);
+
+        final Descriptor d = descriptorFactory.vocabularyDescriptor(vOriginal);
+
+        transactional(() -> {
+            em.persist(vOriginal, d);
+            em.persist(document);
+        });
+
+        final cz.cvut.kbss.termit.model.Vocabulary vUpdate = new cz.cvut.kbss.termit.model.Vocabulary();
+        vUpdate.setUri(vOriginal.getUri());
+        vUpdate.setDocument(document);
+
+        transactional(() -> {
+            sut.rewireDocumentsOnVocabularyUpdate(vOriginal, vUpdate);
+        });
+
+        assertThat(em.find( Document.class, document.getUri(), d ), equalTo(document));
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryServiceTest.java
@@ -136,7 +136,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     @Test
     void updateThrowsValidationExceptionForEmptyName() {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
-        transactional(() -> em.persist(vocabulary));
+        transactional(() -> em.persist(vocabulary, descriptorFor(vocabulary)));
 
         vocabulary.setLabel("");
         assertThrows(ValidationException.class, () -> sut.update(vocabulary));


### PR DESCRIPTION
The goal is to be able to transfer a document from a context to another context (from voc to default when detaching the doc and from default to voc when attaching to voc).

The logic employed:
1. removing the original vocabulary.document
2. evict the cache
3. repersist the original vocabulary.document in the defaultCtx (detaching the doc, so moving to defaultCtx)
4. persist the new vocabulary.document in the vocabularyCtx (attaching the doc)