### PR TITLE
1455 sorted subterms

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/config/WebAppConfig.java
+++ b/src/main/java/cz/cvut/kbss/termit/config/WebAppConfig.java
@@ -149,10 +149,10 @@ public class WebAppConfig implements WebMvcConfigurer {
 
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-        converters.add(createJsonLdMessageConverter());
-        converters.add(createDefaultMessageConverter());
         final StringHttpMessageConverter stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
         converters.add(stringConverter);
+        converters.add(createJsonLdMessageConverter());
+        converters.add(createDefaultMessageConverter());
         converters.add(new ResourceHttpMessageConverter());
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/ResourceDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/ResourceDao.java
@@ -147,7 +147,7 @@ public class ResourceDao extends AssetDao<Resource> implements SupportsLastModif
                     "{ ?y ?hasFile ?x . }" +
                     " UNION " +
                     "{ ?x a ?vocabulary . }" +
-                    "} } ORDER BY ?label", Resource.class)
+                    "} } ORDER BY LCASE(?label)", Resource.class)
                      .setParameter("type", typeUri)
                      .setParameter("hasLabel", labelProperty())
                      .setParameter("hasFile", URI.create(Vocabulary.s_p_ma_soubor))
@@ -175,7 +175,7 @@ public class ResourceDao extends AssetDao<Resource> implements SupportsLastModif
                     "?hasLabel ?label ." +
                     "?assignment ?is-assignment-of ?x ;" +
                     "?has-target/?has-source ?resource ." +
-                    "} ORDER BY ?label", Term.class)
+                    "} ORDER BY LCASE(?label)", Term.class)
                      .setParameter("term", URI.create(getOwlClassForEntity(Term.class)))
                      .setParameter("hasLabel", URI.create(SKOS.PREF_LABEL))
                      .setParameter("is-assignment-of", URI.create(Vocabulary.s_p_je_prirazenim_termu))
@@ -246,14 +246,14 @@ public class ResourceDao extends AssetDao<Resource> implements SupportsLastModif
      */
     private void removeDocumentFromContext(final Document document) {
         if (document.getFiles() != null ) {
-            document.getFiles().forEach( f -> this.remove(f) );
+            document.getFiles().forEach(this::remove);
         }
         this.remove(document);
         this.em.flush();
     }
 
     /**
-     * Adds a document to the context givent by the vocabulary IRI.
+     * Adds a document to the context given by the vocabulary IRI.
      *
      * @param document document
      * @param vocabularyId URI of the vocabulary context

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -114,7 +114,7 @@ public class TermDao extends AssetDao<Term> {
                     "FILTER (lang(?label) = ?labelLang) ." +
                     "}" +
                     "?term ?inVocabulary ?vocabulary ." +
-                    " } ORDER BY ?label", Term.class)
+                    " } ORDER BY LCASE(?label)", Term.class)
                                                  .setParameter("type", typeUri)
                                                  .setParameter("vocabulary", vocabulary.getUri())
                                                  .setParameter("hasLabel", LABEL_PROP)
@@ -174,7 +174,7 @@ public class TermDao extends AssetDao<Term> {
                 "?inVocabulary ?parent ." +
                 "?vocabulary ?imports* ?parent ." +
                 "FILTER (lang(?label) = ?labelLang) ." +
-                "} ORDER BY ?label", Term.class).setParameter("type", typeUri)
+                "} ORDER BY LCASE(?label)", Term.class).setParameter("type", typeUri)
                                    .setParameter("hasLabel", LABEL_PROP)
                                    .setParameter("inVocabulary",
                                            URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_je_pojmem_ze_slovniku))
@@ -198,7 +198,7 @@ public class TermDao extends AssetDao<Term> {
                 "?entity a ?type ;" +
                 "?hasLabel ?label ;" +
                 "?inVocabulary ?vocabulary ." +
-                "FILTER (lang(?label) = ?labelLang) . } ORDER BY ?label", "TermInfo")
+                "FILTER (lang(?label) = ?labelLang) . } ORDER BY LCASE(?label)", "TermInfo")
                                                   .setParameter("type", typeUri)
                                                   .setParameter("narrower", URI.create(SKOS.NARROWER))
                                                   .setParameter("parent", parent.getUri())
@@ -230,16 +230,14 @@ public class TermDao extends AssetDao<Term> {
                 "?hasLabel ?label ." +
                 "?vocabulary ?hasGlossary/?hasTerm ?term ." +
                 "FILTER (lang(?label) = ?labelLang) ." +
-                "}} ORDER BY ?label OFFSET ?offset LIMIT ?limit", Term.class);
+                "}} ORDER BY LCASE(?label)", Term.class);
         query = setCommonFindAllRootsQueryParams(query, false);
         try {
             final List<Term> result = executeQueryAndLoadSubTerms(query.setParameter("vocabulary", vocabulary.getUri())
                                                                        .setParameter("labelLang",
                                                                                config.get(ConfigParam.LANGUAGE))
-                                                                       .setUntypedParameter("offset",
-                                                                               pageSpec.getOffset())
-                                                                       .setUntypedParameter("limit",
-                                                                               pageSpec.getPageSize()));
+                                                                       .setMaxResults(pageSpec.getPageSize())
+                                                                       .setFirstResult((int) pageSpec.getOffset()));
             result.addAll(loadIncludedTerms(includeTerms));
             return result;
         } catch (RuntimeException e) {
@@ -285,16 +283,14 @@ public class TermDao extends AssetDao<Term> {
                 "?vocabulary ?imports* ?parent ." +
                 "?parent ?hasGlossary/?hasTerm ?term ." +
                 "FILTER (lang(?label) = ?labelLang) ." +
-                "} ORDER BY ?label OFFSET ?offset LIMIT ?limit", Term.class);
+                "} ORDER BY LCASE(?label)", Term.class);
         query = setCommonFindAllRootsQueryParams(query, true);
         try {
             final List<Term> result = executeQueryAndLoadSubTerms(query.setParameter("vocabulary", vocabulary.getUri())
                                                                        .setParameter("labelLang",
                                                                                config.get(ConfigParam.LANGUAGE))
-                                                                       .setUntypedParameter("offset",
-                                                                               pageSpec.getOffset())
-                                                                       .setUntypedParameter("limit",
-                                                                               pageSpec.getPageSize()));
+                                                                       .setFirstResult((int) pageSpec.getOffset())
+                                                                       .setMaxResults(pageSpec.getPageSize()));
             result.addAll(loadIncludedTerms(includeTerms));
             return result;
         } catch (RuntimeException e) {
@@ -321,7 +317,7 @@ public class TermDao extends AssetDao<Term> {
                 "FILTER CONTAINS(LCASE(?label), LCASE(?searchString)) ." +
                 "}" +
                 "?term ?inVocabulary ?vocabulary ." +
-                "} ORDER BY ?label", Term.class)
+                "} ORDER BY LCASE(?label)", Term.class)
                                          .setParameter("type", typeUri)
                                          .setParameter("hasLabel", LABEL_PROP)
                                          .setParameter("inVocabulary", URI.create(
@@ -362,7 +358,7 @@ public class TermDao extends AssetDao<Term> {
                 "      ?hasLabel ?label ;\n" +
                 "      ?inVocabulary ?vocabulary ." +
                 "FILTER CONTAINS(LCASE(?label), LCASE(?searchString)) .\n" +
-                "} ORDER BY ?label", Term.class)
+                "} ORDER BY LCASE(?label)", Term.class)
                                          .setParameter("type", typeUri)
                                          .setParameter("hasLabel", LABEL_PROP)
                                          .setParameter("inVocabulary", URI.create(

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -29,10 +29,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -201,7 +198,7 @@ public class TermDao extends AssetDao<Term> {
                 "?entity a ?type ;" +
                 "?hasLabel ?label ;" +
                 "?inVocabulary ?vocabulary ." +
-                "FILTER (lang(?label) = ?labelLang) . }", "TermInfo")
+                "FILTER (lang(?label) = ?labelLang) . } ORDER BY ?label", "TermInfo")
                                                   .setParameter("type", typeUri)
                                                   .setParameter("narrower", URI.create(SKOS.NARROWER))
                                                   .setParameter("parent", parent.getUri())
@@ -211,7 +208,8 @@ public class TermDao extends AssetDao<Term> {
                                                                   cz.cvut.kbss.termit.util.Vocabulary.s_p_je_pojmem_ze_slovniku))
                                                   .setParameter("labelLang", config.get(ConfigParam.LANGUAGE))
                                                   .getResultStream();
-        parent.setSubTerms(subTermsStream.collect(Collectors.toSet()));
+        // Use LinkedHashSet to preserve term order
+        parent.setSubTerms(subTermsStream.collect(Collectors.toCollection(LinkedHashSet::new)));
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -13,6 +13,8 @@ import cz.cvut.kbss.termit.service.comment.CommentService;
 import cz.cvut.kbss.termit.service.export.VocabularyExporters;
 import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.TermRepositoryService;
+import cz.cvut.kbss.termit.util.ConfigParam;
+import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.TypeAwareResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -41,17 +43,20 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
 
     private final CommentService commentService;
 
+    private final Configuration config;
+
     @Autowired
     public TermService(VocabularyExporters exporters, VocabularyService vocabularyService,
                        TermRepositoryService repositoryService,
                        TermOccurrenceService termOccurrenceService, ChangeRecordService changeRecordService,
-                       CommentService commentService) {
+                       CommentService commentService, Configuration config) {
         this.exporters = exporters;
         this.vocabularyService = vocabularyService;
         this.repositoryService = repositoryService;
         this.termOccurrenceService = termOccurrenceService;
         this.changeRecordService = changeRecordService;
         this.commentService = commentService;
+        this.config = config;
     }
 
     /**
@@ -231,6 +236,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
                parent.getSubTerms().stream().map(u -> repositoryService.find(u.getUri()).orElseThrow(
                        () -> new NotFoundException(
                                "Child of term " + parent + " with id " + u.getUri() + " not found!")))
+                     .sorted(Comparator.comparing((Term t) -> t.getLabel().get(config.get(ConfigParam.LANGUAGE))))
                      .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
https://kbss.felk.cvut.cz/redmine/issues/1455

Note that terms whose label starts with a Czech character get pushed to the end anyway due to the way SPARQL ORDER BY works. If we wanted the ordering to take locale into account, we would have to write a custom ordering function for SPARQL or sort the terms in code.