### PR TITLE
je-draft rdfs:range xsd:boolean

### DIFF
--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -52,14 +52,14 @@ termit-pojem:uživatel-termitu
 termit-pojem:má-zdroj-definice-termu
         a                   owl:ObjectProperty , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
         rdfs:domain         <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/term> ;
-        rdfs:range          xsd:boolean ;
-        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .
+        rdfs:range          termit-pojem:zdroj-definice-termu ;
+        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vztah> .
 
 termit-pojem:je-draft
         a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
         rdfs:domain         <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/term> ;
-        rdfs:range          termit-pojem:zdroj-definice-termu ;
-        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vztah> .
+        rdfs:range          xsd:boolean ;
+        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .
 
 <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/term>
         a       owl:Class .


### PR DESCRIPTION
Switched last two rows of following concepts:

termit-pojem:má-zdroj-definice-termu
        a                   owl:ObjectProperty , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
        rdfs:domain         <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/term> ;
        rdfs:range          xsd:boolean ;
        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .
termit-pojem:je-draft
        a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
        rdfs:domain         <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/term> ;
        rdfs:range          termit-pojem:zdroj-definice-termu ;
        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vztah> .