### PR TITLE
[R-#1552] SKOS-only import.

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -73,12 +73,14 @@ public class VocabularyController extends BaseController {
     /**
      * Allows to import a vocabulary (or its  glossary) from the specified file.
      *
+     * @param vocabularyIri IRI of the resulting vocabulary. It is not taken from data, as term IRIs are derived from it.
      * @param file File containing data to import
      */
     @PostMapping("/import")
     @PreAuthorize("hasRole('" + SecurityConstants.ROLE_FULL_USER + "')")
-    public ResponseEntity<Void> createVocabulary(@RequestParam(name = "file") MultipartFile file) {
-        final Vocabulary vocabulary = vocabularyService.importVocabulary(file);
+    public ResponseEntity<Void> createVocabulary(@RequestParam(name = "vocabularyIri") String vocabularyIri,
+                                                 @RequestParam(name = "file") MultipartFile file) {
+        final Vocabulary vocabulary = vocabularyService.importVocabulary(vocabularyIri, file);
         LOG.debug("Vocabulary {} created.", vocabulary);
         final URI location = generateLocation(vocabulary.getUri(), ConfigParam.NAMESPACE_VOCABULARY);
         final String adjustedLocation = location.toString().replace("/import/", "/");

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -45,10 +45,11 @@ public interface VocabularyService
      * The file could be a text file containing RDF, or it could be a ZIP file containing separate vocabulary, glossary
      * and model files.
      *
+     * @param vocabularyIri IRI of the vocabulary to be created.
      * @param file File from which to import the vocabulary
      * @return The imported vocabulary metadata
      */
-    Vocabulary importVocabulary(MultipartFile file);
+    Vocabulary importVocabulary(String vocabularyIri, MultipartFile file);
 
     /**
      * Gets change records of the listed assets.

--- a/src/main/java/cz/cvut/kbss/termit/service/importer/VocabularyImportService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/importer/VocabularyImportService.java
@@ -3,23 +3,13 @@ package cz.cvut.kbss.termit.service.importer;
 import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.persistence.dao.skos.SKOSImporter;
-import cz.cvut.kbss.termit.util.Constants;
+import java.io.IOException;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 /**
  * Allows to import a vocabulary from RDF.
@@ -44,43 +34,18 @@ public class VocabularyImportService {
     /**
      * Import vocabulary from the specified file.
      *
+     * @param vocabularyIri IRI of the vocabulary to be created.
      * @param file File containing the vocabulary to import. Can be a file containing RDF, or a ZIP containing multiple
      *             RDF files
      * @return {@code Vocabulary} object containing metadata of the imported vocabulary
      */
     @Transactional
-    public Vocabulary importVocabulary(MultipartFile file) {
+    public Vocabulary importVocabulary(String vocabularyIri, MultipartFile file) {
         Objects.requireNonNull(file);
         try {
-            if (Constants.ZIP_MEDIA_TYPE.equals(file.getContentType())) {
-                return importFromZipFile(file);
-            } else {
-                return getSKOSImporter().importVocabulary(file.getContentType(), file.getInputStream());
-            }
+            return getSKOSImporter().importVocabulary(vocabularyIri, file.getContentType(), file.getInputStream());
         } catch (IOException e) {
             throw new TermItException("Unable to read file with vocabulary to import.", e);
-        }
-    }
-
-    private Vocabulary importFromZipFile(MultipartFile file) throws IOException {
-        final Path tempFile = Files.createTempFile("vocabulary-import", ".zip");
-        try {
-            file.transferTo(tempFile);
-            try (final ZipFile zipFile = new ZipFile(tempFile.toFile())) {
-                final List<InputStream> lst = new ArrayList<>();
-                final Enumeration<? extends ZipEntry> en = zipFile.entries();
-                String mediaType = null;
-                while (en.hasMoreElements()) {
-                    final ZipEntry ze = en.nextElement();
-                    lst.add(zipFile.getInputStream(ze));
-                    if (mediaType == null) {
-                        mediaType = SKOSImporter.guessMediaType(ze.getName());
-                    }
-                }
-                return getSKOSImporter().importVocabulary(mediaType, lst.toArray(new InputStream[0]));
-            }
-        } finally {
-            Files.delete(tempFile);
         }
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -127,9 +127,9 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
     }
 
     @Override
-    public Vocabulary importVocabulary(MultipartFile file) {
+    public Vocabulary importVocabulary(String vocabularyIri, MultipartFile file) {
         Objects.requireNonNull(file);
-        return importService.importVocabulary(file);
+        return importService.importVocabulary(vocabularyIri, file);
     }
 
     @Override

--- a/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
@@ -160,15 +160,15 @@ class VocabularyControllerTest extends BaseControllerTestRunner {
     void createVocabularyRunsImportWhenFileIsUploaded() throws Exception {
         final Vocabulary vocabulary = Generator.generateVocabulary();
         vocabulary.setUri(URI.create(NAMESPACE + FRAGMENT));
-        when(serviceMock.importVocabulary(any())).thenReturn(vocabulary);
+        when(serviceMock.importVocabulary(any(),any())).thenReturn(vocabulary);
 
         final MockMultipartFile upload = new MockMultipartFile("file", "test-glossary.ttl",
                 Constants.Turtle.MEDIA_TYPE, Environment.loadFile("data/test-glossary.ttl"));
-        final MvcResult mvcResult = mockMvc.perform(multipart(PATH + "/import").file(upload))
+        final MvcResult mvcResult = mockMvc.perform(multipart(PATH + "/import").file(upload).param("vocabularyIri",vocabulary.getUri().toString()))
                 .andExpect(status().isCreated())
                 .andReturn();
         verifyLocationEquals(PATH + "/" + FRAGMENT, mvcResult);
-        verify(serviceMock).importVocabulary(upload);
+        verify(serviceMock).importVocabulary(vocabulary.getUri().toString(), upload);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/importer/VocabularyImportServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/importer/VocabularyImportServiceTest.java
@@ -51,52 +51,11 @@ class VocabularyImportServiceTest {
         final MultipartFile input = new MockMultipartFile("vocabulary.ttl", "vocabulary.ttl",
                 Constants.Turtle.MEDIA_TYPE, Environment.loadFile("vocabularies/ipr-glossaries.ttl"));
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
-        when(importer.importVocabulary(any(), any())).thenReturn(vocabulary);
-        final Vocabulary result = sut.importVocabulary(input);
+        when(importer.importVocabulary(any(), any(), any())).thenReturn(vocabulary);
+        final Vocabulary result = sut.importVocabulary(vocabulary.getUri().toString(),input);
         final ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(importer).importVocabulary(eq(Constants.Turtle.MEDIA_TYPE), captor.capture());
+        verify(importer).importVocabulary(eq(vocabulary.getUri().toString()), eq(Constants.Turtle.MEDIA_TYPE), captor.capture());
         assertNotNull(captor.getValue());
         assertEquals(vocabulary, result);
-    }
-
-    @Test
-    void extractsIndividualFilesFromZipAndPassesTheirInputStreamsToImporter() throws IOException {
-        final MultipartFile input = new MockMultipartFile("vocabulary.zip", "vocabulary.zip",
-                Constants.ZIP_MEDIA_TYPE, generateZipFile().toByteArray());
-        final Vocabulary vocabulary = Generator.generateVocabularyWithId();
-        when(importer.importVocabulary(anyString(), any(InputStream.class))).thenReturn(vocabulary);
-        sut.importVocabulary(input);
-        final ArgumentCaptor<InputStream> captor = ArgumentCaptor.forClass(InputStream.class);
-        verify(importer).importVocabulary(eq(Constants.Turtle.MEDIA_TYPE), captor.capture());
-        assertEquals(2, captor.getAllValues().size());
-    }
-
-    private ByteArrayOutputStream generateZipFile() throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(baos, StandardCharsets.UTF_8)) {
-            ZipEntry entry = new ZipEntry("vocabulary.ttl");
-
-            zos.putNextEntry(entry);
-            try (InputStream is = Environment.loadFile("vocabularies/ipr-glossaries.ttl")) {
-                byte[] bytes = new byte[1024];
-                int length;
-                while ((length = is.read(bytes)) >= 0) {
-                    zos.write(bytes, 0, length);
-                }
-            }
-            zos.closeEntry();
-
-            entry = new ZipEntry("vocabulary2.ttl");
-            zos.putNextEntry(entry);
-            try (InputStream is = Environment.loadFile("vocabularies/ipr-glossaries.ttl")) {
-                byte[] bytes = new byte[1024];
-                int length;
-                while ((length = is.read(bytes)) >= 0) {
-                    zos.write(bytes, 0, length);
-                }
-            }
-            zos.closeEntry();
-        }
-        return baos;
     }
 }


### PR DESCRIPTION
Simplified importing logic and made it SKOS compatible:
- only SKOS-expressed thesauri are importable
- removed the possibility to import a ZIP file
- Vocabulary IRI needs to be provided upfront as it relates to the vocabulary term IRIs.