### PR TITLE
Suppress logging of the UnsupportedOperationException

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/exception/DisabledOperationException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/DisabledOperationException.java
@@ -1,0 +1,9 @@
+package cz.cvut.kbss.termit.exception;
+
+@SuppressibleLogging
+public class DisabledOperationException extends TermItException {
+
+    public DisabledOperationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/exception/SuppressibleLogging.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/SuppressibleLogging.java
@@ -1,0 +1,14 @@
+package cz.cvut.kbss.termit.exception;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks exceptions which need not be logged.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SuppressibleLogging {
+}

--- a/src/main/java/cz/cvut/kbss/termit/exception/TermItException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/TermItException.java
@@ -21,37 +21,18 @@ package cz.cvut.kbss.termit.exception;
  */
 public class TermItException extends RuntimeException {
 
-    protected final boolean suppressLogging;
-
     protected TermItException() {
-        this.suppressLogging = false;
     }
 
     public TermItException(String message) {
-        this(message, false);
-    }
-
-    public TermItException(String message, boolean suppressLogging) {
         super(message);
-        this.suppressLogging = suppressLogging;
     }
 
     public TermItException(String message, Throwable cause) {
         super(message, cause);
-        this.suppressLogging = false;
     }
 
     public TermItException(Throwable cause) {
         super(cause);
-        this.suppressLogging = false;
-    }
-
-    /**
-     * Whether logging of this exception should be suppressed.
-     *
-     * @return True if exception should not be logged
-     */
-    public boolean shouldSuppressLogging() {
-        return suppressLogging;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/exception/TermItException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/TermItException.java
@@ -1,19 +1,16 @@
 /**
- * TermIt
- * Copyright (C) 2019 Czech Technical University in Prague
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * TermIt Copyright (C) 2019 Czech Technical University in Prague
+ * <p>
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ * <p>
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
  */
 package cz.cvut.kbss.termit.exception;
 
@@ -24,18 +21,37 @@ package cz.cvut.kbss.termit.exception;
  */
 public class TermItException extends RuntimeException {
 
+    protected final boolean suppressLogging;
+
     protected TermItException() {
+        this.suppressLogging = false;
     }
 
     public TermItException(String message) {
+        this(message, false);
+    }
+
+    public TermItException(String message, boolean suppressLogging) {
         super(message);
+        this.suppressLogging = suppressLogging;
     }
 
     public TermItException(String message, Throwable cause) {
         super(message, cause);
+        this.suppressLogging = false;
     }
 
     public TermItException(Throwable cause) {
         super(cause);
+        this.suppressLogging = false;
+    }
+
+    /**
+     * Whether logging of this exception should be suppressed.
+     *
+     * @return True if exception should not be logged
+     */
+    public boolean shouldSuppressLogging() {
+        return suppressLogging;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/exception/UnsupportedOperationException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/UnsupportedOperationException.java
@@ -8,8 +8,4 @@ public class UnsupportedOperationException extends TermItException {
     public UnsupportedOperationException(String message) {
         super(message);
     }
-
-    public UnsupportedOperationException(String message, boolean suppressLogging) {
-        super(message, suppressLogging);
-    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/exception/UnsupportedOperationException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/UnsupportedOperationException.java
@@ -8,4 +8,8 @@ public class UnsupportedOperationException extends TermItException {
     public UnsupportedOperationException(String message) {
         super(message);
     }
+
+    public UnsupportedOperationException(String message, boolean suppressLogging) {
+        super(message, suppressLogging);
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
@@ -40,6 +40,13 @@ public class RestExceptionHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(RestExceptionHandler.class);
 
+    private static void logException(TermItException ex) {
+        if (ex.shouldSuppressLogging()) {
+            return;
+        }
+        logException("Exception caught.", ex);
+    }
+
     private static void logException(Throwable ex) {
         logException("Exception caught.", ex);
     }

--- a/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
@@ -41,10 +41,14 @@ public class RestExceptionHandler {
     private static final Logger LOG = LoggerFactory.getLogger(RestExceptionHandler.class);
 
     private static void logException(TermItException ex) {
-        if (ex.shouldSuppressLogging()) {
+        if (shouldSuppressLogging(ex)) {
             return;
         }
         logException("Exception caught.", ex);
+    }
+
+    private static boolean shouldSuppressLogging(TermItException ex) {
+        return ex.getClass().getAnnotation(SuppressibleLogging.class) != null;
     }
 
     private static void logException(Throwable ex) {
@@ -133,6 +137,12 @@ public class RestExceptionHandler {
     @ExceptionHandler(UnsupportedOperationException.class)
     public ResponseEntity<ErrorInfo> unsupportedAssetOperationException(HttpServletRequest request,
                                                                         UnsupportedOperationException e) {
+        logException(e);
+        return new ResponseEntity<>(errorInfo(request, e), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(DisabledOperationException.class)
+    public ResponseEntity<ErrorInfo> disabledOperationException(HttpServletRequest request, DisabledOperationException e) {
         logException(e);
         return new ResponseEntity<>(errorInfo(request, e), HttpStatus.CONFLICT);
     }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -18,6 +18,7 @@ import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermAssignments;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
+import cz.cvut.kbss.termit.exception.DisabledOperationException;
 import cz.cvut.kbss.termit.exception.TermRemovalException;
 import cz.cvut.kbss.termit.exception.UnsupportedOperationException;
 import cz.cvut.kbss.termit.model.Term;
@@ -306,7 +307,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
      * @return List of definitionally related terms of the specified term
      */
     public List<URI> getUnusedTermsInVocabulary(Vocabulary vocabulary) {
-        throw new UnsupportedOperationException("This method is disabled, not working correctly.", true);
+        throw new DisabledOperationException("This method is disabled, not working correctly.");
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -19,6 +19,7 @@ import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermAssignments;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.exception.TermRemovalException;
+import cz.cvut.kbss.termit.exception.UnsupportedOperationException;
 import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.persistence.dao.AssetDao;
@@ -27,9 +28,7 @@ import cz.cvut.kbss.termit.persistence.dao.TermDao;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.service.term.AssertedInferredValueDifferentiator;
 import cz.cvut.kbss.termit.service.term.OrphanedInverseTermRelationshipRemover;
-import cz.cvut.kbss.termit.util.ConfigParam;
 import cz.cvut.kbss.termit.util.Configuration;
-import cz.cvut.kbss.termit.util.Configuration.Persistence;
 import org.apache.jena.vocabulary.SKOS;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -62,7 +61,8 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
 
     public TermRepositoryService(Validator validator, IdentifierResolver idResolver,
                                  Configuration config, TermDao termDao,
-                                 OrphanedInverseTermRelationshipRemover orphanedRelationshipRemover, TermAssignmentDao termAssignmentDao,
+                                 OrphanedInverseTermRelationshipRemover orphanedRelationshipRemover,
+                                 TermAssignmentDao termAssignmentDao,
                                  VocabularyRepositoryService vocabularyService) {
         super(validator);
         this.idResolver = idResolver;
@@ -90,7 +90,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
     @Override
     public void persist(Term instance) {
         throw new UnsupportedOperationException(
-            "Persisting term by itself is not supported. It has to be connected to a vocabulary or a parent term.");
+                "Persisting term by itself is not supported. It has to be connected to a vocabulary or a parent term.");
     }
 
     @Override
@@ -108,8 +108,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
 
     @Override
     protected void postUpdate(Term instance) {
-        final Vocabulary vocabulary =
-            vocabularyService.getRequiredReference(instance.getVocabulary());
+        final Vocabulary vocabulary = vocabularyService.getRequiredReference(instance.getVocabulary());
         if (instance.hasParentInSameVocabulary()) {
             vocabulary.getGlossary().removeRootTerm(instance);
         } else {
@@ -126,13 +125,15 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
         }
         verifyIdentifierUnique(instance);
         instance.setGlossary(vocabulary.getGlossary().getUri());
+
+        assert !instance.hasParentInSameVocabulary();
         addTermAsRootToGlossary(instance, vocabulary.getUri());
         termDao.persist(instance, vocabulary);
     }
 
     private URI generateIdentifier(URI vocabularyUri, MultilingualString multilingualString) {
         return idResolver.generateDerivedIdentifier(vocabularyUri, config.getNamespace().getTerm().getSeparator(),
-            multilingualString.get(config.getPersistence().getLanguage()));
+                multilingualString.get(config.getPersistence().getLanguage()));
     }
 
     private void addTermAsRootToGlossary(Term instance, URI vocabularyIri) {
@@ -146,15 +147,15 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
     public void addChildTerm(Term instance, Term parentTerm) {
         validate(instance);
         final URI vocabularyIri =
-            instance.getVocabulary() != null ? instance.getVocabulary() : parentTerm.getVocabulary();
+                instance.getVocabulary() != null ? instance.getVocabulary() : parentTerm.getVocabulary();
         if (instance.getUri() == null) {
             instance.setUri(generateIdentifier(vocabularyIri, instance.getLabel()));
         }
         verifyIdentifierUnique(instance);
 
-        instance.addParentTerm(parentTerm);
         final Vocabulary vocabulary = vocabularyService.getRequiredReference(vocabularyIri);
         instance.setGlossary(vocabulary.getGlossary().getUri());
+        instance.addParentTerm(parentTerm);
         if (!instance.hasParentInSameVocabulary()) {
             addTermAsRootToGlossary(instance, vocabularyIri);
         }
@@ -305,7 +306,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
      * @return List of definitionally related terms of the specified term
      */
     public List<URI> getUnusedTermsInVocabulary(Vocabulary vocabulary) {
-        throw new UnsupportedOperationException("This method is disabled, not working correctly.");
+        throw new UnsupportedOperationException("This method is disabled, not working correctly.", true);
     }
 
     /**
@@ -320,33 +321,33 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
 
         if (!ai.isEmpty()) {
             throw new TermRemovalException(
-                "Cannot delete the term. It is used for annotating resources : " +
-                    ai.stream().map(TermAssignments::getResourceLabel).collect(
-                        joining(",")));
+                    "Cannot delete the term. It is used for annotating resources : " +
+                            ai.stream().map(TermAssignments::getResourceLabel).collect(
+                                    joining(",")));
         }
 
         final Set<TermInfo> subTerms = instance.getSubTerms();
         if ((subTerms != null) && !subTerms.isEmpty()) {
             throw new TermRemovalException(
-                "Cannot delete the term. It is a parent of other terms : " + subTerms
-                    .stream().map(t -> t.getUri().toString())
-                    .collect(joining(",")));
+                    "Cannot delete the term. It is a parent of other terms : " + subTerms
+                            .stream().map(t -> t.getUri().toString())
+                            .collect(joining(",")));
         }
 
         if (instance.getProperties() != null) {
             Set<String> props = instance.getProperties().keySet();
             List<String> properties = props.stream().filter(s -> (s.startsWith(SKOS.getURI())) && !(
-                s.equalsIgnoreCase(SKOS.changeNote.toString())
-                    || s.equalsIgnoreCase(SKOS.editorialNote.toString())
-                    || s.equalsIgnoreCase(SKOS.historyNote.toString())
-                    || s.equalsIgnoreCase(SKOS.example.toString())
-                    || s.equalsIgnoreCase(SKOS.note.toString())
-                    || s.equalsIgnoreCase(SKOS.scopeNote.toString())
-                    || s.equalsIgnoreCase(SKOS.notation.toString()))).collect(toList());
+                    s.equalsIgnoreCase(SKOS.changeNote.toString())
+                            || s.equalsIgnoreCase(SKOS.editorialNote.toString())
+                            || s.equalsIgnoreCase(SKOS.historyNote.toString())
+                            || s.equalsIgnoreCase(SKOS.example.toString())
+                            || s.equalsIgnoreCase(SKOS.note.toString())
+                            || s.equalsIgnoreCase(SKOS.scopeNote.toString())
+                            || s.equalsIgnoreCase(SKOS.notation.toString()))).collect(toList());
             if (!properties.isEmpty()) {
                 throw new TermRemovalException(
-                    "Cannot delete the term. It is linked to another term through properties "
-                        + String.join(",", properties));
+                        "Cannot delete the term. It is linked to another term through properties "
+                                + String.join(",", properties));
             }
         }
 

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/TermRepositoryServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/TermRepositoryServiceTest.java
@@ -23,6 +23,7 @@ import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.exception.ResourceExistsException;
+import cz.cvut.kbss.termit.exception.UnsupportedOperationException;
 import cz.cvut.kbss.termit.exception.ValidationException;
 import cz.cvut.kbss.termit.model.*;
 import cz.cvut.kbss.termit.model.assignment.Target;


### PR DESCRIPTION
Suppress logging of the UnsupportedOperationException thrown by the `TermRepositoryService.getUnusedTermsInVocabulary` as it was plaguing the logs with repeated useless stack traces.