### PR TITLE
[Upd] Update dependencies. Fix minor post-update issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,16 @@
     </repositories>
 
     <properties>
-        <org.springframework.boot.version>2.4.5</org.springframework.boot.version>
-        <org.springframework.version>5.3.6</org.springframework.version>
-        <org.springframework.security.version>5.4.6</org.springframework.security.version>
+        <org.springframework.boot.version>2.5.2</org.springframework.boot.version>
+        <org.springframework.version>5.3.8</org.springframework.version>
+        <org.springframework.security.version>5.5.1</org.springframework.security.version>
         <org.springframework.data.version>2.5.0</org.springframework.data.version>
-        <com.fasterxml.jackson.version>2.12.1</com.fasterxml.jackson.version>
-        <org.hibernate.validator.version>6.1.7.Final</org.hibernate.validator.version>
+        <com.fasterxml.jackson.version>2.12.4</com.fasterxml.jackson.version>
+        <org.hibernate.validator.version>6.2.0.Final</org.hibernate.validator.version>
         <org.apache.tika.tika-core.version>1.26</org.apache.tika.tika-core.version>
-        <cz.cvut.kbss.jopa.version>0.16.5</cz.cvut.kbss.jopa.version>
-        <cz.cvut.kbss.jsonld.version>0.8.6</cz.cvut.kbss.jsonld.version>
-        <org.aspectj.version>1.9.6</org.aspectj.version>
+        <cz.cvut.kbss.jopa.version>0.17.0</cz.cvut.kbss.jopa.version>
+        <cz.cvut.kbss.jsonld.version>0.8.8</cz.cvut.kbss.jsonld.version>
+        <org.aspectj.version>1.9.7</org.aspectj.version>
 
         <!-- Default value for deployment type property which should otherwise specified on command line -->
         <deployment>DEV</deployment>
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-rio-rdfxml</artifactId>
-            <version>3.6.3</version>
+            <version>3.7.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/cz/cvut/kbss/termit/environment/TestPersistenceFactory.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/TestPersistenceFactory.java
@@ -62,7 +62,7 @@ public class TestPersistenceFactory {
         properties.put(PREFER_MULTILINGUAL_STRING, Boolean.TRUE.toString());
         // OPTIMIZATION: Always use statement retrieval with unbound property. Should spare repository queries
         properties.put(SesameOntoDriverProperties.SESAME_LOAD_ALL_THRESHOLD, "1");
-        properties.put(SesameOntoDriverProperties.SESAME_REPOSITORY_CONFIG, "rdf4j-memory-spin-rdfs.ttl");
+        properties.put(SesameOntoDriverProperties.SESAME_REPOSITORY_CONFIG, "classpath:rdf4j-memory-spin-rdfs.ttl");
         this.emf = Persistence.createEntityManagerFactory("termitTestPU", properties);
     }
 

--- a/src/test/resources/rdf4j-memory-spin-rdfs.ttl
+++ b/src/test/resources/rdf4j-memory-spin-rdfs.ttl
@@ -23,9 +23,9 @@
 			 	 sail:sailType "openrdf:DedupingInferencer" ;
 				 sail:delegate [
 					sail:sailType "openrdf:MemoryStore" ;
-					sail:iterationCacheSyncThreshold "{%Query Iteration Cache sync threshold|10000%}";
+					sail:iterationCacheSyncThreshold "10000";
 					ms:persist false ;
-					sb:evaluationStrategyFactory "{%EvaluationStrategyFactory|org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory%}"
+					sb:evaluationStrategyFactory "org.eclipse.rdf4j.query.algebra.evaluation.impl.StrictEvaluationStrategyFactory"
 				 ]
 		 	]
       	]


### PR DESCRIPTION
Update dependencies.

The main reason is updating to JB4JSON-LD 0.8.8 which fixes an issue with deserialization of plural multilingual attributes. The problem was that originally each value in any language got its own instance of `MultilingualString` in the collection. However, this was registered as a change by TermIt's change tracking, even though the values haven't actually changed. The updated version attempts to deserialize multilingual string values into as few `MultilingualString` elements as possible, similarly to the way JOPA does it when loading data from the repository. This fixes the change tracking issue.

See, for example, the history of "Pojem osmnáct" in the ML test vocabulary on termit-dev.