### PR TITLE
[Bug #1634] Recursively load subterms of all ancestors of terms explicincluded in root terms retrieval

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/dto/listing/TermDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/listing/TermDto.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 /**
  * DTO for term listing.
  * <p>
- * Contains less data than a regular {@link cz.cvut.kbss.termit.model.Term}.
+ * Contains fewer data than a regular {@link cz.cvut.kbss.termit.model.Term}.
  */
 @OWLClass(iri = SKOS.CONCEPT)
 @JsonLdAttributeOrder({"uri", "label", "subTerms"})
@@ -39,5 +39,9 @@ public class TermDto extends AbstractTerm {
 
     public void setParentTerms(Set<TermDto> parentTerms) {
         this.parentTerms = parentTerms;
+    }
+
+    public boolean hasParentTerms() {
+        return parentTerms != null && !parentTerms.isEmpty();
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/model/Glossary.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/Glossary.java
@@ -17,13 +17,12 @@
  */
 package cz.cvut.kbss.termit.model;
 
+import cz.cvut.kbss.jopa.model.annotations.FetchType;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
-import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.util.Vocabulary;
 
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Objects;
@@ -77,13 +76,5 @@ public class Glossary extends AbstractEntity {
         return "Glossary{" +
                 "term count=" + (rootTerms != null ? rootTerms.size() : 0) +
                 " " + super.toString() + "}";
-    }
-
-    public static Field getTermsField() {
-        try {
-            return Glossary.class.getDeclaredField("rootTerms");
-        } catch (NoSuchFieldException e) {
-            throw new TermItException("Fatal error! Unable to retrieve \"rootTerms\" field.", e);
-        }
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -327,7 +327,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> {
     }
 
     /**
-     * Gets all unused (unassigned to, neither occuring in a resource) terms in the given vocabulary
+     * Gets all unused (unassigned to, neither occurring in a resource) terms in the given vocabulary
      *
      * @param vocabulary - IRI of the vocabulary in which the terms are
      * @return List of definitionally related terms of the specified term

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoExactMatchTermsTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoExactMatchTermsTest.java
@@ -59,7 +59,7 @@ public class TermDaoExactMatchTermsTest extends BaseDaoTestRunner {
                 em.persist(t, descriptorFactory.termDescriptor(t));
                 Generator.addTermInVocabularyRelationship(t, t.getVocabulary(), em);
             });
-            generateRelationships(term, exactMatchTerms, SKOS.EXACT_MATCH);
+            generateRelationships(term, exactMatchTerms);
         });
 
         final Optional<Term> result = sut.find(term.getUri());
@@ -68,14 +68,14 @@ public class TermDaoExactMatchTermsTest extends BaseDaoTestRunner {
         exactMatchTerms.forEach(rt -> assertThat(result.get().getInverseExactMatchTerms(), hasItem(new TermInfo(rt))));
     }
 
-    private void generateRelationships(Term term, Collection<Term> related, String relationship) {
+    private void generateRelationships(Term term, Collection<Term> related) {
         final Repository repo = em.unwrap(Repository.class);
         try (final RepositoryConnection conn = repo.getConnection()) {
             final ValueFactory vf = conn.getValueFactory();
             conn.begin();
             for (Term r : related) {
                 // Don't put it into any specific context to make it look like inference
-                conn.add(vf.createIRI(r.getUri().toString()), vf.createIRI(relationship), vf.createIRI(term.getUri().toString()));
+                conn.add(vf.createIRI(r.getUri().toString()), vf.createIRI(SKOS.EXACT_MATCH), vf.createIRI(term.getUri().toString()));
             }
             conn.commit();
         }
@@ -94,7 +94,7 @@ public class TermDaoExactMatchTermsTest extends BaseDaoTestRunner {
                 em.persist(t, descriptorFactory.termDescriptor(t.getVocabulary()));
                 Generator.addTermInVocabularyRelationship(t, t.getVocabulary(), em);
             });
-            generateRelationships(term, inverseExactMatchTerms, SKOS.EXACT_MATCH);
+            generateRelationships(term, inverseExactMatchTerms);
         });
         term.setExactMatchTerms(exactMatchTerms.stream().map(TermInfo::new).collect(Collectors.toSet()));
         transactional(() -> em.merge(term, descriptorFactory.termDescriptor(term)));

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoExactMatchTermsTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoExactMatchTermsTest.java
@@ -59,7 +59,7 @@ public class TermDaoExactMatchTermsTest extends BaseDaoTestRunner {
                 em.persist(t, descriptorFactory.termDescriptor(t));
                 Generator.addTermInVocabularyRelationship(t, t.getVocabulary(), em);
             });
-            generateRelationships(term, exactMatchTerms);
+            generateExactMatchRelationships(term, exactMatchTerms);
         });
 
         final Optional<Term> result = sut.find(term.getUri());
@@ -68,7 +68,7 @@ public class TermDaoExactMatchTermsTest extends BaseDaoTestRunner {
         exactMatchTerms.forEach(rt -> assertThat(result.get().getInverseExactMatchTerms(), hasItem(new TermInfo(rt))));
     }
 
-    private void generateRelationships(Term term, Collection<Term> related) {
+    private void generateExactMatchRelationships(Term term, Collection<Term> related) {
         final Repository repo = em.unwrap(Repository.class);
         try (final RepositoryConnection conn = repo.getConnection()) {
             final ValueFactory vf = conn.getValueFactory();
@@ -94,7 +94,7 @@ public class TermDaoExactMatchTermsTest extends BaseDaoTestRunner {
                 em.persist(t, descriptorFactory.termDescriptor(t.getVocabulary()));
                 Generator.addTermInVocabularyRelationship(t, t.getVocabulary(), em);
             });
-            generateRelationships(term, inverseExactMatchTerms);
+            generateExactMatchRelationships(term, inverseExactMatchTerms);
         });
         term.setExactMatchTerms(exactMatchTerms.stream().map(TermInfo::new).collect(Collectors.toSet()));
         transactional(() -> em.merge(term, descriptorFactory.termDescriptor(term)));

--- a/src/test/java/cz/cvut/kbss/termit/rest/ConfigurationControllerSecurityTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/ConfigurationControllerSecurityTest.java
@@ -7,11 +7,14 @@ import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.environment.config.TestRestSecurityConfig;
 import cz.cvut.kbss.termit.model.UserRole;
 import cz.cvut.kbss.termit.service.config.ConfigurationProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -39,6 +42,12 @@ public class ConfigurationControllerSecurityTest extends BaseControllerTestRunne
     @Autowired
     private MockMvc mockMvc;
 
+    @BeforeEach
+    void setUp() {
+        Environment.resetCurrentUser();
+    }
+
+    @WithMockUser
     @Test
     void getConfigurationReturnsFullConfigurationWhenUserIsAuthenticated() throws Exception {
         Environment.setCurrentUser(Generator.generateUserAccountWithPassword());
@@ -63,6 +72,7 @@ public class ConfigurationControllerSecurityTest extends BaseControllerTestRunne
         return config;
     }
 
+    @WithAnonymousUser
     @Test
     void getConfigurationReturnsConfigurationWithoutRolesWhenUserIsNotAuthenticated() throws Exception {
         final ConfigurationDto config = generateConfiguration();


### PR DESCRIPTION
https://kbss.felk.cvut.cz/redmine/issues/1634

Not strictly necessary for the reworked term loading logic on the frontend, but returns more consistent data structure.