### PR TITLE
Skos export symmetric properties

### DIFF
--- a/src/main/resources/query/export/full/exportGlossaryTerms.rq
+++ b/src/main/resources/query/export/full/exportGlossaryTerms.rq
@@ -8,6 +8,8 @@ CONSTRUCT {
           skos:broader ?broader ;
           skos:broadMatch ?broadMatch ;
         skos:related ?related ;
+        skos:exactMatch ?exactMatch ;
+        skos:relatedMatch ?relatedMatch ;
     	skos:topConceptOf ?topOf ;
         a ?type ;
         skos:broader ?superClass ;
@@ -72,8 +74,13 @@ CONSTRUCT {
             }
         }
 	}
-    FILTER (?y NOT IN (skos:broader, skos:broadMatch, skos:related, rdfs:subClassOf))
-
+    FILTER (?y NOT IN (skos:broader, skos:broadMatch, skos:related, rdfs:subClassOf, skos:relatedMatch, skos:exactMatch))
+    OPTIONAL {
+        ?term skos:relatedMatch ?relatedMatch .
+    }
+    OPTIONAL {
+        ?term skos:exactMatch ?exactMatch .
+    }
     OPTIONAL {
         ?whole <http://onto.fel.cvut.cz/ontologies/ufo/has-part> ?term .
         FILTER NOT EXISTS {

--- a/src/main/resources/query/export/skos/exportGlossaryTerms.rq
+++ b/src/main/resources/query/export/skos/exportGlossaryTerms.rq
@@ -56,12 +56,6 @@ CONSTRUCT {
             }
         }
         OPTIONAL {
-            ?term skos:relatedMatch ?relatedMatch .
-        }
-        OPTIONAL {
-            ?term skos:exactMatch ?exactMatch .
-        }
-        OPTIONAL {
         # This ensures only parent-less terms become top concepts of their glossaries
             BIND(IF(EXISTS {?glossary skos:hasTopConcept ?term}, ?glossary, BNODE()) as ?topOf)
             FILTER (!ISBLANK(?topOf))
@@ -86,6 +80,12 @@ CONSTRUCT {
                 FILTER (!sameTerm(?term, ?superClass) && !sameTerm(?term, ?intermediateSuperClass) && !sameTerm(?superClass, ?intermediateSuperClass))
             }
         }
+    }
+    OPTIONAL {
+        ?term skos:relatedMatch ?relatedMatch .
+    }
+    OPTIONAL {
+        ?term skos:exactMatch ?exactMatch .
     }
     OPTIONAL {
         ?whole <http://onto.fel.cvut.cz/ontologies/ufo/has-part> ?term .


### PR DESCRIPTION
Another revision of kbss-cvut/termit-ui#296 implementation. This time, the SKOS export should include inferred SKOS mapping relationships (`exactMatch`, `relatedMatch`).