### PR TITLE
Change of Change Tracking Contexts for KODI

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -23,9 +23,13 @@ public class ChangeRecordDao {
 
     private final EntityManager em;
 
-    public ChangeRecordDao(ChangeTrackingContextResolver contextResolver, EntityManager em) {
+    private final ChangeTrackingContextResolver changeTrackingContextResolver;
+
+    public ChangeRecordDao(ChangeTrackingContextResolver contextResolver, EntityManager em,
+                           ChangeTrackingContextResolver changeTrackingContextResolver) {
         this.contextResolver = contextResolver;
         this.em = em;
+        this.changeTrackingContextResolver = changeTrackingContextResolver;
     }
 
     /**
@@ -58,13 +62,16 @@ public class ChangeRecordDao {
         Objects.requireNonNull(asset);
         try {
             final Descriptor descriptor = new EntityDescriptor();
+            URI changeTrackingContextUri = changeTrackingContextResolver.resolveChangeTrackingContext(asset);
             descriptor.setLanguage(null);
             return em.createNativeQuery("SELECT ?r WHERE {" +
+                             "GRAPH ?ctc { ?r ?relatesTo ?asset . }" +
                              "?r a ?changeRecord ;" +
                              "?relatesTo ?asset ;" +
                              "?hasTime ?timestamp ." +
                              "OPTIONAL { ?r ?hasChangedAttribute ?attribute . }" +
                              "} ORDER BY DESC(?timestamp) ?attribute", AbstractChangeRecord.class)
+                     .setParameter("ctc", changeTrackingContextUri)
                      .setParameter("changeRecord", URI.create(Vocabulary.s_c_zmena))
                      .setParameter("relatesTo", URI.create(Vocabulary.s_p_ma_zmenenou_entitu))
                      .setParameter("hasChangedAttribute", URI.create(Vocabulary.s_p_ma_zmeneny_atribut))

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -64,12 +64,11 @@ public class ChangeRecordDao {
             final Descriptor descriptor = new EntityDescriptor();
             URI changeTrackingContextUri = changeTrackingContextResolver.resolveChangeTrackingContext(asset);
             descriptor.setLanguage(null);
-            return em.createNativeQuery("SELECT ?r WHERE {" +
-                             "GRAPH ?ctc { ?r ?relatesTo ?asset . }" +
-                             "?r a ?changeRecord ;" +
-                             "?relatesTo ?asset ;" +
-                             "?hasTime ?timestamp ." +
-                             "OPTIONAL { ?r ?hasChangedAttribute ?attribute . }" +
+            return em.createNativeQuery("SELECT ?r WHERE { " +
+                             "GRAPH ?ctc { ?r ?relatesTo ?asset ; " +
+                             "?hasTime ?timestamp . " +
+                             "OPTIONAL { ?r ?hasChangedAttribute ?attribute . } } " +
+                             "?r a ?changeRecord . " +
                              "} ORDER BY DESC(?timestamp) ?attribute", AbstractChangeRecord.class)
                      .setParameter("ctc", changeTrackingContextUri)
                      .setParameter("changeRecord", URI.create(Vocabulary.s_c_zmena))

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -3,6 +3,7 @@ package cz.cvut.kbss.termit.persistence.dao.changetracking;
 import cz.cvut.kbss.jopa.model.EntityManager;
 import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
+import cz.cvut.kbss.termit.exception.NotFoundException;
 import cz.cvut.kbss.termit.exception.PersistenceException;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.User;
@@ -77,6 +78,8 @@ public class ChangeRecordDao {
                      .setParameter("hasTime", URI.create(Vocabulary.s_p_ma_datum_a_cas_modifikace))
                      .setParameter("asset", asset.getUri()).setDescriptor(descriptor).getResultList();
         } catch (RuntimeException e) {
+            if(e instanceof NotFoundException)
+                throw e;
             throw new PersistenceException(e);
         }
     }

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeTrackingContextResolver.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeTrackingContextResolver.java
@@ -5,6 +5,8 @@ import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.util.Configuration;
+import cz.cvut.kbss.termit.workspace.EditableVocabularies;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -21,10 +23,13 @@ public class ChangeTrackingContextResolver {
 
     private final String contextExtension;
 
+    private final EditableVocabularies vocabularies;
+
     @Autowired
-    public ChangeTrackingContextResolver(EntityManager em, Configuration config) {
+    public ChangeTrackingContextResolver(EntityManager em, Configuration config, EditableVocabularies vocabularies) {
         this.em = em;
         this.contextExtension = config.getChangetracking().getContext().getExtension();
+        this.vocabularies = vocabularies;
     }
 
     /**
@@ -39,8 +44,14 @@ public class ChangeTrackingContextResolver {
     public URI resolveChangeTrackingContext(Asset<?> changedAsset) {
         Objects.requireNonNull(changedAsset);
         if (changedAsset instanceof Vocabulary) {
+            URI changeTrackingContextURI = resolveExistingChangeTrackingContext(changedAsset.getUri());
+            if(Objects.nonNull(changeTrackingContextURI))
+                return changeTrackingContextURI;
             return URI.create(changedAsset.getUri().toString().concat(contextExtension));
         } else if (changedAsset instanceof Term) {
+            URI changeTrackingContextURI = resolveExistingChangeTrackingContext(resolveTermVocabulary((Term) changedAsset));
+            if(Objects.nonNull(changeTrackingContextURI))
+                return changeTrackingContextURI;
             return URI.create(resolveTermVocabulary((Term) changedAsset).toString().concat(contextExtension));
         }
         return URI.create(changedAsset.getUri().toString().concat(contextExtension));
@@ -54,8 +65,19 @@ public class ChangeTrackingContextResolver {
         } else {
             return em.createNativeQuery("SELECT DISTINCT ?v WHERE { ?t ?inVocabulary ?v . }", URI.class)
                      .setParameter("inVocabulary",
-                                   URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_je_pojmem_ze_slovniku))
+                             URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_je_pojmem_ze_slovniku))
                      .setParameter("t", term).getSingleResult();
         }
+    }
+
+    private URI resolveExistingChangeTrackingContext(URI vocabularyURI) {
+        Optional<URI> vocabularyContext = vocabularies.getVocabularyContext(vocabularyURI);
+        return vocabularyContext.map(uri -> em.createNativeQuery(
+                                                      "SELECT DISTINCT ?ctc WHERE { GRAPH ?vc { ?vc ?hasChangeTrackingContext ?ctc } }", URI.class)
+                                              .setParameter("vc", uri)
+                                              .setParameter("hasChangeTrackingContext",
+                                                      URI.create(
+                                                              cz.cvut.kbss.termit.util.Vocabulary.s_i_ma_kontext_sledovani_zmen))
+                                              .getSingleResult()).orElse(null);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeTrackingContextResolver.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeTrackingContextResolver.java
@@ -77,7 +77,7 @@ public class ChangeTrackingContextResolver {
                                               .setParameter("vc", uri)
                                               .setParameter("hasChangeTrackingContext",
                                                       URI.create(
-                                                              cz.cvut.kbss.termit.util.Vocabulary.s_i_ma_kontext_sledovani_zmen))
+                                                              cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_kontext_sledovani_zmen))
                                               .getSingleResult()).orElse(null);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeTrackingContextResolverTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeTrackingContextResolverTest.java
@@ -7,6 +7,7 @@ import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.resource.Resource;
 import cz.cvut.kbss.termit.util.Configuration;
+import cz.cvut.kbss.termit.workspace.EditableVocabularies;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +39,7 @@ class ChangeTrackingContextResolverTest {
     @BeforeEach
     void setUp() {
         when(config.getChangetracking().getContext().getExtension()).thenReturn(CHANGE_CONTEXT_EXTENSION);
-        this.sut = new ChangeTrackingContextResolver(em, config);
+        this.sut = new ChangeTrackingContextResolver(em, config, new EditableVocabularies(config));
     }
 
     @Test


### PR DESCRIPTION
I changed where change tracking data are stored for Vocabulary Contexts (VCs) so that it stores changes made in VC to a different named graph (prepared on VC creation by SGOV) than canonical changes. 

In my quick testing, the implementation did not change the behaviour of the standalone TermIt.