### PR TITLE
Test update for change tracking context

### DIFF
--- a/src/test/java/cz/cvut/kbss/termit/service/repository/ChangeRecordServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/ChangeRecordServiceTest.java
@@ -1,15 +1,19 @@
 package cz.cvut.kbss.termit.service.repository;
 
 import cz.cvut.kbss.jopa.model.EntityManager;
+import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
+import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
+import cz.cvut.kbss.termit.model.Glossary;
 import cz.cvut.kbss.termit.model.User;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.changetracking.UpdateChangeRecord;
 import cz.cvut.kbss.termit.persistence.context.DescriptorFactory;
 import cz.cvut.kbss.termit.service.BaseServiceTestRunner;
+import cz.cvut.kbss.termit.util.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,13 +38,22 @@ class ChangeRecordServiceTest extends BaseServiceTestRunner {
     @Autowired
     private ChangeRecordService sut;
 
+    @Autowired
+    private Configuration config;
+
     private User author;
 
     private Vocabulary asset;
 
+    private String contextExtension;
+
     @BeforeEach
     void setUp() {
+        this.contextExtension = config.getChangetracking().getContext().getExtension();
         this.asset = Generator.generateVocabularyWithId();
+        Glossary glossary = new Glossary();
+        glossary.setUri(Generator.generateUri());
+        asset.setGlossary(glossary);
         this.author = Generator.generateUserWithId();
         Environment.setCurrentUser(author);
         transactional(() -> {
@@ -60,6 +73,7 @@ class ChangeRecordServiceTest extends BaseServiceTestRunner {
     }
 
     private List<AbstractChangeRecord> generateChanges() {
+        Descriptor descriptor = persistDescriptor(URI.create(asset.getUri().toString().concat(contextExtension)));
         final List<AbstractChangeRecord> records = IntStream.range(0, 5).mapToObj(i -> {
             final UpdateChangeRecord r = new UpdateChangeRecord(asset);
             r.setChangedAttribute(URI.create(DC.Terms.TITLE));
@@ -67,7 +81,14 @@ class ChangeRecordServiceTest extends BaseServiceTestRunner {
             r.setTimestamp(Instant.ofEpochMilli(System.currentTimeMillis() - i * 10000L));
             return r;
         }).collect(Collectors.toList());
-        transactional(() -> records.forEach(em::persist));
+        transactional(() -> records.forEach(record -> em.persist(record, descriptor)));
         return records;
+    }
+
+    private Descriptor persistDescriptor(URI context) {
+        final EntityDescriptor descriptor = new EntityDescriptor(context);
+        descriptor.addAttributeDescriptor(em.getMetamodel().entity(AbstractChangeRecord.class).getAttribute("author"),
+                new EntityDescriptor());
+        return descriptor;
     }
 }


### PR DESCRIPTION
Just realized I pushed test changes to a different branch in KODI, so they were not included in the last PR #204 

The issue with the tests was that the changeRecords were persisted to the default graph and not to changeTrackingContext graph of the asset (as is the case in deployed usage).