### PR TITLE
Termit UI#294 empty string values

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -35,6 +35,7 @@ import cz.cvut.kbss.termit.service.snapshot.SnapshotProvider;
 import cz.cvut.kbss.termit.service.term.AssertedInferredValueDifferentiator;
 import cz.cvut.kbss.termit.service.term.OrphanedInverseTermRelationshipRemover;
 import cz.cvut.kbss.termit.util.Configuration;
+import cz.cvut.kbss.termit.util.Utils;
 import org.apache.jena.vocabulary.SKOS;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -101,6 +102,16 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> impl
         differentiator.differentiateExactMatchTerms(instance, original);
         orphanedRelationshipRemover.removeOrphanedInverseTermRelationships(instance, original);
         instance.splitExternalAndInternalParents();
+        pruneEmptyTranslations(instance);
+    }
+
+    private void pruneEmptyTranslations(Term instance) {
+        assert instance != null;
+        Utils.pruneBlankTranslations(instance.getLabel());
+        Utils.pruneBlankTranslations(instance.getDefinition());
+        Utils.pruneBlankTranslations(instance.getDescription());
+        Utils.emptyIfNull(instance.getAltLabels()).forEach(Utils::pruneBlankTranslations);
+        Utils.emptyIfNull(instance.getHiddenLabels()).forEach(Utils::pruneBlankTranslations);
     }
 
     @Override
@@ -143,6 +154,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term> impl
             instance.setUri(generateIdentifier(vocabularyUri, instance.getLabel()));
         }
         verifyIdentifierUnique(instance);
+        pruneEmptyTranslations(instance);
     }
 
     private URI generateIdentifier(URI vocabularyUri, MultilingualString multilingualString) {

--- a/src/main/java/cz/cvut/kbss/termit/util/Configuration.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/Configuration.java
@@ -522,7 +522,6 @@ public class Configuration {
         /**
          * URL of the text analysis service.
          */
-        @NotNull
         String url;
 
         /**

--- a/src/main/java/cz/cvut/kbss/termit/util/Utils.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/Utils.java
@@ -3,6 +3,7 @@ package cz.cvut.kbss.termit.util;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.parser.Parser;
 import com.vladsch.flexmark.util.ast.Node;
+import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.termit.exception.ResourceNotFoundException;
 import cz.cvut.kbss.termit.exception.TermItException;
 import org.eclipse.rdf4j.model.*;
@@ -12,7 +13,10 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.safety.Safelist;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -318,5 +322,22 @@ public class Utils {
         final HtmlRenderer renderer = HtmlRenderer.builder().build();
         final String html = renderer.render(document);
         return htmlToPlainText(html);
+    }
+
+    /**
+     * Removes blank translations from the specified {@link MultilingualString}.
+     * <p>
+     * That is, deletes records in languages where the value is a blank string.
+     *
+     * @param str Multilingual string to prune, possibly {@code null}
+     */
+    public static void pruneBlankTranslations(MultilingualString str) {
+        if (str == null) {
+            return;
+        }
+        // TODO Rewrite to entrySet.removeIf once JOPA MultilingualString.getValue does not return unmodifiable Map
+        final Set<String> langsToRemove = str.getValue().entrySet().stream().filter(e -> e.getValue().isBlank())
+                                             .map(Map.Entry::getKey).collect(Collectors.toSet());
+        langsToRemove.forEach(str::remove);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/document/TextAnalysisServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/TextAnalysisServiceTest.java
@@ -335,4 +335,16 @@ class TextAnalysisServiceTest extends BaseServiceTestRunner {
         mockServer.verify();
         verify(annotationGeneratorMock, never()).generateAnnotations(any(), any(Term.class));
     }
+
+    @Test
+    void analyzeTermDefinitionDoesNothingWhenTextAnalysisServiceUrlIsNotConfigured() {
+        final Term term = Generator.generateTermWithId();
+        term.setVocabulary(vocabulary.getUri());
+        config.getTextAnalysis().setUrl(null);
+
+        sut.analyzeTermDefinition(term, vocabulary.getUri());
+        mockServer.verify();
+        verify(annotationGeneratorMock, never()).generateAnnotations(any(), any(Term.class));
+        verify(textAnalysisRecordDao, never()).persist(any());
+    }
 }

--- a/src/test/java/cz/cvut/kbss/termit/util/UtilsTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/util/UtilsTest.java
@@ -1,22 +1,20 @@
 /**
- * TermIt
- * Copyright (C) 2019 Czech Technical University in Prague
+ * TermIt Copyright (C) 2019 Czech Technical University in Prague
  * <p>
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later
+ * version.
  * <p>
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
  * <p>
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with this program.  If not, see
+ * <https://www.gnu.org/licenses/>.
  */
 package cz.cvut.kbss.termit.util;
 
+import cz.cvut.kbss.jopa.model.MultilingualString;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -55,7 +53,7 @@ class UtilsTest {
 
     @Test
     public void getUniqueIriFromBaseReturnsBaseIfCheckSucceeds() {
-        final Function f = Mockito.mock(Function.class);
+        final Function<String, Optional<Object>> f = Mockito.mock(Function.class);
         when(f.apply(BASE)).thenReturn(Optional.of(new Object()));
         when(f.apply(BASE + "-0")).thenReturn(Optional.empty());
         Assert.equals(BASE + "-0", Utils.getUniqueIriFromBase(BASE, f));
@@ -100,9 +98,8 @@ class UtilsTest {
 
     @Test
     public void getVocabularyIriThrowsExceptionIfNoConceptIsProvided() {
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            Utils.getVocabularyIri(Collections.emptySet(), "/pojem");
-        });
+        Assertions.assertThrows(IllegalArgumentException.class,
+                                () -> Utils.getVocabularyIri(Collections.emptySet(), "/pojem"));
     }
 
     @Test
@@ -110,9 +107,7 @@ class UtilsTest {
         final Set<String> conceptIris = new HashSet<>();
         conceptIris.add("https://example.org/pojem/A");
         conceptIris.add("https://example2.org/pojem/B");
-        Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            Utils.getVocabularyIri(conceptIris, "/pojem");
-        });
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Utils.getVocabularyIri(conceptIris, "/pojem"));
     }
 
     @Test
@@ -176,8 +171,9 @@ class UtilsTest {
         model.add(iriA, iriP1, f.createLiteral("a label cs", "cs"));
         model.add(iriA, iriP2, f.createLiteral("a label"));
 
-        final Set<String> expected = Stream.of("cs","").collect(Collectors.toSet());
-        final Set<String> actual = Utils.getLanguageTagsPerProperties(model, Stream.of(p1, p2).collect(Collectors.toSet()));
+        final Set<String> expected = Stream.of("cs", "").collect(Collectors.toSet());
+        final Set<String> actual = Utils.getLanguageTagsPerProperties(model,
+                                                                      Stream.of(p1, p2).collect(Collectors.toSet()));
 
         assertEquals(expected, actual);
     }
@@ -222,5 +218,15 @@ class UtilsTest {
         final String text = "This is text without any markup.\n" +
                 "It uses just newline";
         assertEquals(text, Utils.htmlToPlainText(text));
+    }
+
+    @Test
+    void pruneBlankTranslationsRemovesTranslationsThatAreBlankStrings() {
+        final MultilingualString str = MultilingualString.create("test", "en");
+        str.set("cs", "");
+        str.set("de", "   ");
+        Utils.pruneBlankTranslations(str);
+        assertEquals(1, str.getValue().size());
+        assertEquals("test", str.get("en"));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -29,7 +29,7 @@ termit:
     file:
         storage: /tmp/termit
     textAnalysis:
-        url:
+        url: http://localhost/annotace
         termAssignmentMinScore: 1
         termOccurrenceMinScore: 0.49
     comments:


### PR DESCRIPTION
Fixes kbss-cvut/termit-ui#294.

Existing data should be cleared up via a SPARQL query.