### PR TITLE
Fix error with text analysis

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -12,6 +12,7 @@ import cz.cvut.kbss.termit.model.assignment.TermDefinitionSource;
 import cz.cvut.kbss.termit.model.assignment.TermOccurrence;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.comment.Comment;
+import cz.cvut.kbss.termit.persistence.context.VocabularyContextMapper;
 import cz.cvut.kbss.termit.service.changetracking.ChangeRecordProvider;
 import cz.cvut.kbss.termit.service.comment.CommentService;
 import cz.cvut.kbss.termit.service.document.TextAnalysisService;
@@ -57,11 +58,13 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
 
     private final Configuration config;
 
+    private final VocabularyContextMapper contextMapper;
+
     @Autowired
     public TermService(VocabularyExporters exporters, VocabularyService vocabularyService,
                        TermRepositoryService repositoryService, TextAnalysisService textAnalysisService,
                        TermOccurrenceService termOccurrenceService, ChangeRecordService changeRecordService,
-                       CommentService commentService, Configuration config) {
+                       CommentService commentService, Configuration config, VocabularyContextMapper contextMapper) {
         this.exporters = exporters;
         this.vocabularyService = vocabularyService;
         this.repositoryService = repositoryService;
@@ -70,6 +73,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         this.changeRecordService = changeRecordService;
         this.commentService = commentService;
         this.config = config;
+        this.contextMapper = contextMapper;
     }
 
     /**
@@ -381,7 +385,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         Objects.requireNonNull(term);
         final Term original = repositoryService.findRequired(term.getUri());
         if (!Objects.equals(original.getDefinition(), term.getDefinition())) {
-            analyzeTermDefinition(term, term.getVocabulary());
+            analyzeTermDefinition(term, contextMapper.getVocabularyContext(term.getVocabulary()));
         }
         final Term result = repositoryService.update(term);
         // Ensure the change is merged into the repo before analyzing other terms

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -385,7 +385,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         Objects.requireNonNull(term);
         final Term original = repositoryService.findRequired(term.getUri());
         if (!Objects.equals(original.getDefinition(), term.getDefinition())) {
-            analyzeTermDefinition(term, contextMapper.getVocabularyContext(term.getVocabulary()));
+            analyzeTermDefinition(term, term.getVocabulary());
         }
         final Term result = repositoryService.update(term);
         // Ensure the change is merged into the repo before analyzing other terms
@@ -412,15 +412,16 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      * A vocabulary with the specified identifier is used as base for the text analysis (its terms are searched for
      * during the analysis).
      *
-     * @param term              Term to analyze
-     * @param vocabularyContext Identifier of the vocabulary used for analysis
+     * @param term       Term to analyze
+     * @param vocabulary Identifier of the vocabulary used for analysis
      */
-    public void analyzeTermDefinition(AbstractTerm term, URI vocabularyContext) {
+    public void analyzeTermDefinition(AbstractTerm term, URI vocabulary) {
         Objects.requireNonNull(term);
         if (term.getDefinition().isEmpty()) {
             return;
         }
         LOG.debug("Analyzing definition of term {}.", term);
+        URI vocabularyContext = contextMapper.getVocabularyContext(vocabulary);
         textAnalysisService.analyzeTermDefinition(term, vocabularyContext);
     }
 

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -14,6 +14,7 @@ import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.assignment.FileOccurrenceTarget;
 import cz.cvut.kbss.termit.model.assignment.TermDefinitionSource;
 import cz.cvut.kbss.termit.model.comment.Comment;
+import cz.cvut.kbss.termit.persistence.context.VocabularyContextMapper;
 import cz.cvut.kbss.termit.service.comment.CommentService;
 import cz.cvut.kbss.termit.service.document.TextAnalysisService;
 import cz.cvut.kbss.termit.service.export.ExportFormat;
@@ -67,6 +68,9 @@ class TermServiceTest {
 
     @Mock
     private CommentService commentService;
+
+    @Mock
+    private VocabularyContextMapper contextMapper;
 
     @Spy
     private Configuration configuration = new Configuration();
@@ -303,6 +307,7 @@ class TermServiceTest {
         toUpdate.setVocabulary(vocabulary.getUri());
         when(termRepositoryService.findRequired(toUpdate.getUri())).thenReturn(original);
         toUpdate.setDefinition(MultilingualString.create(newDefinition, Environment.LANGUAGE));
+        when(contextMapper.getVocabularyContext(vocabulary.getUri())).thenReturn(vocabulary.getUri());
         sut.update(toUpdate);
         verify(textAnalysisService).analyzeTermDefinition(toUpdate, toUpdate.getVocabulary());
     }

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -278,6 +278,8 @@ class TermServiceTest {
     @Test
     void runTextAnalysisInvokesTextAnalysisOnSpecifiedTerm() {
         final Term toAnalyze = generateTermWithId();
+        toAnalyze.setVocabulary(vocabulary.getUri());
+        when(contextMapper.getVocabularyContext(vocabulary.getUri())).thenReturn(vocabulary.getUri());
         sut.analyzeTermDefinition(toAnalyze, vocabulary.getUri());
         verify(textAnalysisService).analyzeTermDefinition(toAnalyze, vocabulary.getUri());
     }
@@ -286,6 +288,7 @@ class TermServiceTest {
     void persistChildInvokesTextAnalysisOnPersistedChildTerm() {
         final Term parent = generateTermWithId();
         parent.setVocabulary(vocabulary.getUri());
+        when(contextMapper.getVocabularyContext(vocabulary.getUri())).thenReturn(vocabulary.getUri());
         final Term childToPersist = generateTermWithId();
         sut.persistChild(childToPersist, parent);
         verify(textAnalysisService).analyzeTermDefinition(childToPersist, parent.getVocabulary());
@@ -294,6 +297,8 @@ class TermServiceTest {
     @Test
     void persistRootInvokesTextAnalysisOnPersistedRootTerm() {
         final Term toPersist = generateTermWithId();
+        toPersist.setVocabulary(vocabulary.getUri());
+        when(contextMapper.getVocabularyContext(vocabulary.getUri())).thenReturn(vocabulary.getUri());
         sut.persistRoot(toPersist, vocabulary);
         verify(textAnalysisService).analyzeTermDefinition(toPersist, vocabulary.getUri());
     }


### PR DESCRIPTION
Consider two drafts `A` and `B`, from the same canonical vocabulary. When rewriting definition of a term `a1` in vocabulary draft `A` and using word that is the same as term in vocabulary draft `B` that is not present in `A`. Update of term `a1` fails on text analysis.