### PR TITLE
[Hotfix] Fix broken Springdoc API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <java.version>17</java.version>
         <org.apache.tika.tika-core.version>2.7.0</org.apache.tika.tika-core.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
-        <org.springdoc.version>1.7.0</org.springdoc.version>
+        <org.springdoc.version>2.2.0</org.springdoc.version>
         <cz.cvut.kbss.jopa.version>1.1.2</cz.cvut.kbss.jopa.version>
         <cz.cvut.kbss.jsonld.version>0.13.2</cz.cvut.kbss.jsonld.version>
         <org.aspectj.version>1.9.20</org.aspectj.version>
@@ -295,12 +295,7 @@
         <!-- REST API documentation -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>${org.springdoc.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-security</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${org.springdoc.version}</version>
         </dependency>
 


### PR DESCRIPTION
Was caused by migration to Spring Boot 3.