### PR TITLE
[kbss-cvut/termit-ui#459] Ensure vocabulary is available when getting data for readonly terms

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
@@ -87,11 +87,18 @@ public class ReadOnlyTermService {
 
     public List<ReadOnlyTerm> findSubTerms(ReadOnlyTerm parent) {
         Objects.requireNonNull(parent);
-        final Term arg = new Term(parent.getUri());
+        final Term arg = toTerm(parent);
         if (parent.getSubTerms() != null) {
             arg.setSubTerms(parent.getSubTerms());
         }
         return termService.findSubTerms(arg).stream().map(this::create).collect(Collectors.toList());
+    }
+
+    private static Term toTerm(ReadOnlyTerm roTerm) {
+        final Term t = new Term(roTerm.getUri());
+        // Ensure vocabulary is set on the Term instance as it may be referenced later
+        t.setVocabulary(roTerm.getVocabulary());
+        return t;
     }
 
     /**
@@ -132,13 +139,13 @@ public class ReadOnlyTermService {
 
     public List<Snapshot> findSnapshots(ReadOnlyTerm asset) {
         Objects.requireNonNull(asset);
-        final Term arg = new Term(asset.getUri());
+        final Term arg = toTerm(asset);
         return termService.findSnapshots(arg);
     }
 
     public ReadOnlyTerm findVersionValidAt(ReadOnlyTerm asset, Instant at) {
         Objects.requireNonNull(asset);
-        final Term arg = new Term(asset.getUri());
+        final Term arg = toTerm(asset);
         return create(termService.findVersionValidAt(arg, at));
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermServiceTest.java
@@ -261,4 +261,23 @@ class ReadOnlyTermServiceTest {
                                                                              .get(DC.Terms.REFERENCES)));
         assertThat(result.getProperties(), not(hasEntry(DC.Elements.DATE, term.getProperties().get(DC.Elements.DATE))));
     }
+
+    @Test
+    void findSubTermsPassesTermWithVocabularyToUnderlyingServiceForTermSubTermResolution() {
+        when(configuration.getPublicView()).thenReturn(new Configuration.PublicView());
+        final Vocabulary vocabulary = Generator.generateVocabularyWithId();
+
+        final Term term = Generator.generateTermWithId();
+        term.setVocabulary(vocabulary.getUri());
+        final List<Term> subTerms = Generator.generateTermsWithIds(3);
+        term.setSubTerms(subTerms.stream().map(TermInfo::new).collect(Collectors.toSet()));
+        when(termService.findSubTerms(any())).thenReturn(subTerms);
+
+        sut.findSubTerms(new ReadOnlyTerm(term));
+        final ArgumentCaptor<Term> captor = ArgumentCaptor.forClass(Term.class);
+        verify(termService).findSubTerms(captor.capture());
+        final Term arg = captor.getValue();
+        assertEquals(term.getUri(), arg.getUri());
+        assertEquals(term.getVocabulary(), arg.getVocabulary());
+    }
 }


### PR DESCRIPTION
Fixes kbss-cvut/termit-ui#459.