### PR TITLE
[Enhancement kbss-cvut/termit-ui#505] Support for sending parameterized error messages to client

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/exception/TermItException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/TermItException.java
@@ -17,6 +17,13 @@
  */
 package cz.cvut.kbss.termit.exception;
 
+import cz.cvut.kbss.termit.util.Utils;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Application-specific exception.
  * <p>
@@ -25,15 +32,34 @@ package cz.cvut.kbss.termit.exception;
 public class TermItException extends RuntimeException {
 
     /**
-     * Identifier of localized frontend message.
+     * Error message identifier.
+     * <p>
+     * This identifier can be used by the UI to display a corresponding localized error message.
      */
-    private String messageId;
+    protected String messageId;
+
+    /**
+     * Exception related information
+     */
+    protected final Map<String, String> parameters = new HashMap<>();
 
     protected TermItException() {
+        messageId = null;
     }
 
     public TermItException(String message) {
         super(message);
+        messageId = null;
+    }
+
+    public TermItException(String message, Throwable cause) {
+        super(message, cause);
+        this.messageId = null;
+    }
+
+    public TermItException(Throwable cause) {
+        super(cause);
+        this.messageId = null;
     }
 
     public TermItException(String message, String messageId) {
@@ -41,24 +67,41 @@ public class TermItException extends RuntimeException {
         this.messageId = messageId;
     }
 
-    public TermItException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public TermItException(String message, String messageId, Throwable cause) {
+    public TermItException(String message, Throwable cause, String messageId) {
         super(message, cause);
         this.messageId = messageId;
     }
 
-    public TermItException(Throwable cause) {
-        super(cause);
+    public TermItException(String message, Throwable cause, String messageId, @NonNull Map<String, String> parameters) {
+        super(message, cause);
+        this.messageId = messageId;
+        addParameters(parameters);
     }
 
+    public TermItException addParameters(@NonNull Map<String, String> parameters) {
+        this.parameters.putAll(parameters);
+        return this;
+    }
+
+    public TermItException addParameter(@NonNull String key, @NonNull String value) {
+        this.parameters.put(key, value);
+        return this;
+    }
+
+    @Nullable
     public String getMessageId() {
         return messageId;
     }
 
-    public void setMessageId(String messageId) {
-        this.messageId = messageId;
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public String toString() {
+        String params = Utils.mapToString(parameters);
+        return super.toString() +
+                (messageId == null ? "" : ", messageId=" + messageId) +
+                (params.isBlank() ? "" : ", parameters=" + params);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/exception/importing/VocabularyImportException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/importing/VocabularyImportException.java
@@ -24,24 +24,15 @@ import cz.cvut.kbss.termit.exception.TermItException;
  */
 public class VocabularyImportException extends TermItException {
 
-    private final String messageId;
-
     public VocabularyImportException(String message) {
         super(message);
-        this.messageId = null;
     }
 
     public VocabularyImportException(String message, String messageId) {
-        super(message);
-        this.messageId = messageId;
+        super(message, messageId);
     }
 
     public VocabularyImportException(String message, Throwable cause) {
         super(message, cause);
-        this.messageId = null;
-    }
-
-    public String getMessageId() {
-        return messageId;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/handler/ErrorInfo.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/handler/ErrorInfo.java
@@ -17,16 +17,33 @@
  */
 package cz.cvut.kbss.termit.rest.handler;
 
+import cz.cvut.kbss.termit.util.Utils;
+
+import java.util.Map;
+
 /**
  * Contains information about an error and can be sent to client as JSON to let him know what is wrong.
  */
 public class ErrorInfo {
 
+    /**
+     * Readable message describing the error
+     */
     private String message;
 
+    /**
+     * Error message identifier.
+     * <p>
+     * This identifier can be used by the UI to display a corresponding localized error message.
+     */
     private String messageId;
 
     private String requestUri;
+
+    /**
+     * Parameters for translatable message identified by {@link #messageId}
+     */
+    private Map<String, String> values;
 
     public ErrorInfo() {
     }
@@ -66,9 +83,17 @@ public class ErrorInfo {
         this.requestUri = requestUri;
     }
 
+    public Map<String, String> getValues() {
+        return values;
+    }
+
+    public void setValues(Map<String, String> parameters) {
+        this.values = parameters;
+    }
+
     @Override
     public String toString() {
-        return "ErrorInfo{" + requestUri + ", messageId=" + messageId + ", message='" + message + "'}";
+        return "ErrorInfo{" + requestUri + ", messageId=" + messageId + ", message='" + message + "', parameters='"+ Utils.mapToString(values) +"'}";
     }
 
     /**
@@ -99,6 +124,21 @@ public class ErrorInfo {
     public static ErrorInfo createWithMessageAndMessageId(String message, String messageId, String requestUri) {
         ErrorInfo errorInfo = createWithMessage(message, requestUri);
         errorInfo.setMessageId(messageId);
+        return errorInfo;
+    }
+
+    public static ErrorInfo createParametrized(String messageId, String requestUri, Map<String, String> values) {
+        final ErrorInfo errorInfo = new ErrorInfo(requestUri);
+        errorInfo.setMessageId(messageId);
+        errorInfo.setValues(values);
+        return errorInfo;
+    }
+
+    public static ErrorInfo createParametrizedWithMessage(String message, String messageId, String requestUri, Map<String, String> values) {
+        final ErrorInfo errorInfo = new ErrorInfo(requestUri);
+        errorInfo.setMessage(message);
+        errorInfo.setMessageId(messageId);
+        errorInfo.setValues(values);
         return errorInfo;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
@@ -95,7 +95,7 @@ public class RestExceptionHandler {
     }
 
     private static ErrorInfo errorInfo(HttpServletRequest request, TermItException e) {
-        return ErrorInfo.createWithMessageAndMessageId(e.getMessage(), e.getMessageId(), request.getRequestURI());
+        return ErrorInfo.createParametrizedWithMessage(e.getMessage(), e.getMessageId(), request.getRequestURI(), e.getParameters());
     }
 
     @ExceptionHandler(PersistenceException.class)
@@ -191,9 +191,7 @@ public class RestExceptionHandler {
     public ResponseEntity<ErrorInfo> vocabularyImportException(HttpServletRequest request,
                                                                VocabularyImportException e) {
         logException(e, request);
-        return new ResponseEntity<>(
-                ErrorInfo.createWithMessageAndMessageId(e.getMessage(), e.getMessageId(), request.getRequestURI()),
-                HttpStatus.CONFLICT);
+        return new ResponseEntity<>(errorInfo(request, e), HttpStatus.CONFLICT);
     }
 
     @ExceptionHandler

--- a/src/main/java/cz/cvut/kbss/termit/service/importer/excel/ExcelImporter.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/importer/excel/ExcelImporter.java
@@ -126,7 +126,10 @@ public class ExcelImporter implements VocabularyImporter {
                                                                                              lang);
                          if (existingUri.isPresent() && !existingUri.get().equals(t.getUri())) {
                              throw new VocabularyImportException(
-                                     "Vocabulary already contains a term with label '" + value + "' with a different identifier than the imported one.");
+                                     "Vocabulary already contains a term with label '" + value + "' with a different identifier than the imported one.",
+                                     "error.vocabulary.import.excel.labelWithDifferentIdentifierExists")
+                                     .addParameter("label", value)
+                                     .addParameter("existingUri", Utils.uriToString(existingUri.get()));
                          }
                      }))
                      .filter(t -> termService.exists(t.getUri())).forEach(t -> {

--- a/src/main/java/cz/cvut/kbss/termit/util/Utils.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/Utils.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -397,5 +398,19 @@ public class Utils {
             return;
         }
         str.getValue().entrySet().removeIf(e -> e.getValue().isBlank());
+    }
+
+    /**
+     * Converts the map into a string
+     * @return Empty string when the map is {@code null}, otherwise the String in format
+     * {@code {key=value, key=value}}
+     */
+    public static <A, B> String mapToString(Map<A, B> map) {
+        if (map == null) {
+            return "";
+        }
+        return map.keySet().stream()
+                           .map(key -> key + "=" + map.get(key))
+                           .collect(Collectors.joining(", ", "{", "}"));
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
@@ -85,7 +85,7 @@ public class WebSocketExceptionHandler {
     }
 
     private static ErrorInfo errorInfo(Message<?> message, TermItException e) {
-        return ErrorInfo.createWithMessageAndMessageId(e.getMessage(), e.getMessageId(), destination(message));
+        return ErrorInfo.createParametrizedWithMessage(e.getMessage(), e.getMessageId(), destination(message), e.getParameters());
     }
 
     @MessageExceptionHandler


### PR DESCRIPTION
resolves kbss-cvut/termit-ui#505

the map attribute in `ErrorInfo` named as `values` to match attribute in `Message` on the FE