### PR TITLE
[Bug kbss-cvut/termit-ui#511] URI validating on persist or update

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/exception/InvalidIdentifierException.java
+++ b/src/main/java/cz/cvut/kbss/termit/exception/InvalidIdentifierException.java
@@ -5,4 +5,8 @@ public class InvalidIdentifierException extends TermItException {
     public InvalidIdentifierException(String message, String messageId) {
         super(message, messageId);
     }
+
+    public InvalidIdentifierException(String message, Throwable cause, String messageId) {
+        super(message, cause, messageId);
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
@@ -40,6 +40,7 @@ import cz.cvut.kbss.termit.exception.ValidationException;
 import cz.cvut.kbss.termit.exception.WebServiceIntegrationException;
 import cz.cvut.kbss.termit.exception.importing.UnsupportedImportMediaTypeException;
 import cz.cvut.kbss.termit.exception.importing.VocabularyImportException;
+import cz.cvut.kbss.termit.util.ExceptionUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,6 +52,9 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.net.URISyntaxException;
+import java.util.Optional;
 
 import static cz.cvut.kbss.termit.util.ExceptionUtils.isCausedBy;
 
@@ -85,7 +89,7 @@ public class RestExceptionHandler {
 
     private static void logException(String message, Throwable ex) {
         // Prevents exceptions caused by broken connection with a client from logging
-        if (!isCausedBy(ex, AsyncRequestNotUsableException.class)) {
+        if (isCausedBy(ex, AsyncRequestNotUsableException.class).isEmpty()) {
             LOG.error(message, ex);
         }
     }
@@ -175,6 +179,10 @@ public class RestExceptionHandler {
     @ExceptionHandler(JsonLdException.class)
     public ResponseEntity<ErrorInfo> jsonLdException(HttpServletRequest request, JsonLdException e) {
         logException(e, request);
+        Optional<URISyntaxException> uriSyntaxException = ExceptionUtils.isCausedBy(e, URISyntaxException.class);
+        if (uriSyntaxException.isPresent()) {
+            return uriSyntaxException(request, uriSyntaxException.get());
+        }
         return new ResponseEntity<>(
                 ErrorInfo.createWithMessage("Error when processing JSON-LD.", request.getRequestURI()),
                 HttpStatus.INTERNAL_SERVER_ERROR);
@@ -267,5 +275,19 @@ public class RestExceptionHandler {
                                                                 InvalidIdentifierException e) {
         logException(e, request);
         return new ResponseEntity<>(errorInfo(request, e), HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorInfo> uriSyntaxException(HttpServletRequest request, URISyntaxException e) {
+        logException(e, request);
+        // when the index is less than zero, its unknown, and we will use more general message
+        final String messageId = e.getIndex() < 0 ? "error.invalidIdentifier" : "error.invalidUriCharacter";
+        TermItException exception = new InvalidIdentifierException(e.getMessage(), e, messageId)
+                .addParameter("uri", e.getInput())
+                .addParameter("reason", e.getReason())
+                .addParameter("message", e.getMessage())
+                .addParameter("index", Integer.toString(e.getIndex()))
+                .addParameter("char", Character.toString(e.getInput().charAt(e.getIndex())));
+        return new ResponseEntity<>(errorInfo(request, exception), HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/handler/RestExceptionHandler.java
@@ -56,7 +56,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import java.net.URISyntaxException;
 import java.util.Optional;
 
-import static cz.cvut.kbss.termit.util.ExceptionUtils.isCausedBy;
+import static cz.cvut.kbss.termit.util.ExceptionUtils.findCause;
 
 /**
  * Exception handlers for REST controllers.
@@ -89,7 +89,7 @@ public class RestExceptionHandler {
 
     private static void logException(String message, Throwable ex) {
         // Prevents exceptions caused by broken connection with a client from logging
-        if (isCausedBy(ex, AsyncRequestNotUsableException.class).isEmpty()) {
+        if (findCause(ex, AsyncRequestNotUsableException.class).isEmpty()) {
             LOG.error(message, ex);
         }
     }
@@ -179,7 +179,7 @@ public class RestExceptionHandler {
     @ExceptionHandler(JsonLdException.class)
     public ResponseEntity<ErrorInfo> jsonLdException(HttpServletRequest request, JsonLdException e) {
         logException(e, request);
-        Optional<URISyntaxException> uriSyntaxException = ExceptionUtils.isCausedBy(e, URISyntaxException.class);
+        Optional<URISyntaxException> uriSyntaxException = ExceptionUtils.findCause(e, URISyntaxException.class);
         if (uriSyntaxException.isPresent()) {
             return uriSyntaxException(request, uriSyntaxException.get());
         }

--- a/src/main/java/cz/cvut/kbss/termit/service/IdentifierResolver.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/IdentifierResolver.java
@@ -152,11 +152,17 @@ public class IdentifierResolver {
         } catch (IllegalArgumentException e) {
             throw new InvalidIdentifierException(
                     "Generated identifier " + namespace + localPart + " is not a valid URI.",
+                    e,
                     "error.identifier.invalidCharacters");
         }
     }
 
-    private static boolean isUri(String value) {
+    /**
+     * @param value the URI to check
+     * @return {@code true} when the URI is prefixed with protocol ({@code http/s, ftp or file}
+     * and it is a valid {@link URI}. {@code false} otherwise
+     */
+    public static boolean isUri(String value) {
         try {
             if (!value.matches("^(https?|ftp|file)://.+")) {
                 return false;

--- a/src/main/java/cz/cvut/kbss/termit/service/document/html/TextPositionSelectorGenerator.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/html/TextPositionSelectorGenerator.java
@@ -22,11 +22,8 @@ import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
-import org.jsoup.select.NodeTraversor;
-import org.jsoup.select.NodeVisitor;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Generates a {@link TextPositionSelector} for the specified elements.

--- a/src/main/java/cz/cvut/kbss/termit/util/ExceptionUtils.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/ExceptionUtils.java
@@ -3,6 +3,7 @@ package cz.cvut.kbss.termit.util;
 import org.springframework.lang.NonNull;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public class ExceptionUtils {
@@ -11,21 +12,22 @@ public class ExceptionUtils {
     }
 
     /**
-     * Resolves all nested causes of the {@code throwable} and returns true if any is matching the {@code cause}
+     * Resolves all nested causes of the {@code throwable}
+     * @return any cause of the {@code throwable} matching the {@code cause} class, or empty when not found
      */
-    public static boolean isCausedBy(final Throwable throwable, @NonNull final Class<? extends Throwable> cause) {
+    public static <T extends Throwable> Optional<T> isCausedBy(final Throwable throwable, @NonNull final Class<T> cause) {
         Throwable t = throwable;
         final Set<Throwable> visited = new HashSet<>();
         while (t != null) {
             if(visited.add(t)) {
                 if (cause.isInstance(t)){
-                    return true;
+                    return Optional.of((T) t);
                 }
                 t = t.getCause();
                 continue;
             }
             break;
         }
-        return false;
+        return Optional.empty();
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/util/ExceptionUtils.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/ExceptionUtils.java
@@ -15,7 +15,7 @@ public class ExceptionUtils {
      * Resolves all nested causes of the {@code throwable}
      * @return any cause of the {@code throwable} matching the {@code cause} class, or empty when not found
      */
-    public static <T extends Throwable> Optional<T> isCausedBy(final Throwable throwable, @NonNull final Class<T> cause) {
+    public static <T extends Throwable> Optional<T> findCause(final Throwable throwable, @NonNull final Class<T> cause) {
         Throwable t = throwable;
         final Set<Throwable> visited = new HashSet<>();
         while (t != null) {

--- a/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
@@ -40,7 +40,7 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import java.net.URISyntaxException;
 
-import static cz.cvut.kbss.termit.util.ExceptionUtils.isCausedBy;
+import static cz.cvut.kbss.termit.util.ExceptionUtils.findCause;
 
 /**
  * @implSpec Should reflect {@link cz.cvut.kbss.termit.rest.handler.RestExceptionHandler}
@@ -77,7 +77,7 @@ public class WebSocketExceptionHandler {
 
     private static void logException(String message, Throwable ex) {
         // Prevents exceptions caused by broken connection with a client from logging
-        if (isCausedBy(ex, AsyncRequestNotUsableException.class).isEmpty()) {
+        if (findCause(ex, AsyncRequestNotUsableException.class).isEmpty()) {
             LOG.error(message, ex);
         }
     }

--- a/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
@@ -76,7 +76,7 @@ public class WebSocketExceptionHandler {
     }
 
     private static void logException(String message, Throwable ex) {
-        // prevents from logging exceptions caused by broken connection with a client
+        // Prevents exceptions caused by broken connection with a client from logging
         if (isCausedBy(ex, AsyncRequestNotUsableException.class).isEmpty()) {
             LOG.error(message, ex);
         }

--- a/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/cz/cvut/kbss/termit/websocket/handler/WebSocketExceptionHandler.java
@@ -38,6 +38,8 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+import java.net.URISyntaxException;
+
 import static cz.cvut.kbss.termit.util.ExceptionUtils.isCausedBy;
 
 /**
@@ -74,8 +76,8 @@ public class WebSocketExceptionHandler {
     }
 
     private static void logException(String message, Throwable ex) {
-        // prevents from logging exceptions caused be broken connection with a client
-        if (!isCausedBy(ex, AsyncRequestNotUsableException.class)) {
+        // prevents from logging exceptions caused by broken connection with a client
+        if (isCausedBy(ex, AsyncRequestNotUsableException.class).isEmpty()) {
             LOG.error(message, ex);
         }
     }
@@ -260,6 +262,12 @@ public class WebSocketExceptionHandler {
 
     @MessageExceptionHandler
     public ErrorInfo invalidIdentifierException(Message<?> message, InvalidIdentifierException e) {
+        logException(e, message);
+        return errorInfo(message, e);
+    }
+
+    @MessageExceptionHandler
+    public ErrorInfo uriSyntaxException(Message<?> message, URISyntaxException e) {
         logException(e, message);
         return errorInfo(message, e);
     }


### PR DESCRIPTION
resolves kbss-cvut/termit-ui#511

`BaseRepositoryService` will now perform additional validation of the URI before each persist and update.

URI is valid when it is null or valid URI according to `IdentifierResolver#isUri`.

`RestExceptionHandler` will now provide more detailed information on `URISyntaxException`.
