### PR TITLE
[Enhancement kbss-cvut/termit-ui#519] Term history in vocabulary

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/model/changetracking/AbstractChangeRecord.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/changetracking/AbstractChangeRecord.java
@@ -27,6 +27,7 @@ import cz.cvut.kbss.termit.model.AbstractEntity;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.User;
 import cz.cvut.kbss.termit.util.Vocabulary;
+import jakarta.annotation.Nonnull;
 
 import java.net.URI;
 import java.time.Instant;
@@ -37,7 +38,7 @@ import java.util.Objects;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "className")
 @OWLClass(iri = Vocabulary.s_c_zmena)
-public class AbstractChangeRecord extends AbstractEntity {
+public class AbstractChangeRecord extends AbstractEntity implements Comparable<AbstractChangeRecord> {
 
     @ParticipationConstraints(nonEmpty = true)
     @OWLDataProperty(iri = Vocabulary.s_p_ma_datum_a_cas_modifikace)
@@ -105,5 +106,15 @@ public class AbstractChangeRecord extends AbstractEntity {
                 ", timestamp=" + timestamp +
                 ", author=" + author +
                 ", changedEntity=" + changedEntity;
+    }
+
+    @Override
+    public int compareTo(@Nonnull AbstractChangeRecord o) {
+        final int timestampDiff = getTimestamp().compareTo(o.getTimestamp());
+        if (timestampDiff != 0) {
+            return timestampDiff;
+        }
+
+        return getUri().compareTo(o.getUri());
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/model/changetracking/PersistChangeRecord.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/changetracking/PersistChangeRecord.java
@@ -20,6 +20,7 @@ package cz.cvut.kbss.termit.model.changetracking;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.util.Vocabulary;
+import jakarta.annotation.Nonnull;
 
 @OWLClass(iri = Vocabulary.s_c_vytvoreni_entity)
 public class PersistChangeRecord extends AbstractChangeRecord {
@@ -34,5 +35,13 @@ public class PersistChangeRecord extends AbstractChangeRecord {
     @Override
     public String toString() {
         return "PersistChangeRecord{" + super.toString() + '}';
+    }
+
+    @Override
+    public int compareTo(@Nonnull AbstractChangeRecord o) {
+        if (o instanceof UpdateChangeRecord) {
+            return -1;
+        }
+        return super.compareTo(o);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/model/changetracking/UpdateChangeRecord.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/changetracking/UpdateChangeRecord.java
@@ -23,6 +23,7 @@ import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.util.Vocabulary;
+import jakarta.annotation.Nonnull;
 
 import java.net.URI;
 import java.util.Objects;
@@ -97,5 +98,13 @@ public class UpdateChangeRecord extends AbstractChangeRecord {
                 super.toString() +
                 "changedAttribute=" + changedAttribute +
                 "}";
+    }
+
+    @Override
+    public int compareTo(@Nonnull AbstractChangeRecord o) {
+        if (o instanceof PersistChangeRecord) {
+            return 1;
+        }
+        return super.compareTo(o);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -56,6 +56,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PostFilter;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -295,6 +296,17 @@ public class VocabularyService
      */
     public List<AggregatedChangeInfo> getChangesOfContent(Vocabulary vocabulary) {
         return repositoryService.getChangesOfContent(vocabulary);
+    }
+
+    /**
+     * Gets content change records of the specified vocabulary.
+     *
+     * @param vocabulary Vocabulary whose content changes to get
+     * @param pageReq Specification of the size and number of the page to return
+     * @return List of change records, ordered by date in descending order
+     */
+    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, Pageable pageReq) {
+        return repositoryService.getDetailedHistoryOfContent(vocabulary, pageReq);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -29,6 +29,7 @@ import cz.cvut.kbss.termit.exception.importing.VocabularyImportException;
 import cz.cvut.kbss.termit.model.Glossary;
 import cz.cvut.kbss.termit.model.Model;
 import cz.cvut.kbss.termit.model.Vocabulary;
+import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.resource.Document;
 import cz.cvut.kbss.termit.model.validation.ValidationResult;
 import cz.cvut.kbss.termit.persistence.dao.BaseAssetDao;
@@ -52,6 +53,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -216,6 +218,18 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
     @Transactional(readOnly = true)
     public List<AggregatedChangeInfo> getChangesOfContent(Vocabulary vocabulary) {
         return vocabularyDao.getChangesOfContent(vocabulary);
+    }
+
+    /**
+     * Gets content change records of the specified vocabulary.
+     *
+     * @param vocabulary Vocabulary whose content changes to get
+     * @param pageReq Specification of the size and number of the page to return
+     * @return List of change records, ordered by date in descending order
+     */
+    @Transactional(readOnly = true)
+    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, Pageable pageReq) {
+        return vocabularyDao.getDetailedHistoryOfContent(vocabulary, pageReq);
     }
 
     @CacheEvict(allEntries = true)


### PR DESCRIPTION
resolves kbss-cvut/termit-ui#519

Adds `/vocabularies/{localName}/history-of-content/detail` endpoint, which returns change records of vocabulary terms.