### PR TITLE
[Enhancement kbss-cvut/termit-ui#520] Change record filtering

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/dto/filter/ChangeRecordFilterDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/filter/ChangeRecordFilterDto.java
@@ -15,6 +15,22 @@ public class ChangeRecordFilterDto {
     private String authorName = "";
     private URI changeType = null;
 
+    public ChangeRecordFilterDto() {
+    }
+
+    public ChangeRecordFilterDto(String changedAttributeName, String authorName, URI changeType) {
+        this.changedAttributeName = changedAttributeName;
+        this.authorName = authorName;
+        this.changeType = changeType;
+    }
+
+    public ChangeRecordFilterDto(String assetLabel, String changedAttributeName, String authorName, URI changeType) {
+        this.assetLabel = assetLabel;
+        this.changedAttributeName = changedAttributeName;
+        this.authorName = authorName;
+        this.changeType = changeType;
+    }
+
     public String getAssetLabel() {
         return assetLabel;
     }

--- a/src/main/java/cz/cvut/kbss/termit/dto/filter/ChangeRecordFilterDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/filter/ChangeRecordFilterDto.java
@@ -72,4 +72,19 @@ public class ChangeRecordFilterDto {
     public int hashCode() {
         return Objects.hash(assetLabel, changedAttributeName, authorName, changeType);
     }
+
+
+    /**
+     * Constants for the Open API documentation of the REST API.
+     */
+    public static final class ApiDoc {
+        public static final String TERM_NAME_DESCRIPTION = "Name of the term used for filtering.";
+        public static final String CHANGE_TYPE_DESCRIPTION = "Type of the change used for filtering.";
+        public static final String AUTHOR_NAME_DESCRIPTION = "Name of the author of the change used for filtering.";
+        public static final String CHANGED_ATTRIBUTE_DESCRIPTION = "Name of the changed attribute used for filtering.";
+
+        private ApiDoc() {
+            throw new AssertionError();
+        }
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/filter/ChangeRecordFilterDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/filter/ChangeRecordFilterDto.java
@@ -1,23 +1,26 @@
 package cz.cvut.kbss.termit.dto.filter;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import cz.cvut.kbss.termit.util.Utils;
+
 import java.net.URI;
 import java.util.Objects;
 
 /**
  * Represents parameters for filtering vocabulary content changes.
  */
-public class VocabularyContentChangeFilterDto {
-    private String termName = "";
+public class ChangeRecordFilterDto {
+    private String assetLabel = "";
     private String changedAttributeName = "";
     private String authorName = "";
     private URI changeType = null;
 
-    public String getTermName() {
-        return termName;
+    public String getAssetLabel() {
+        return assetLabel;
     }
 
-    public void setTermName(String termName) {
-        this.termName = termName;
+    public void setAssetLabel(String assetLabel) {
+        this.assetLabel = assetLabel;
     }
 
     public String getChangedAttributeName() {
@@ -44,11 +47,22 @@ public class VocabularyContentChangeFilterDto {
         this.changeType = changeType;
     }
 
+    /**
+     * @return true when all attributes are empty or null
+     */
+    @JsonIgnore
+    public boolean isEmpty() {
+        return Utils.isBlank(assetLabel) &&
+                Utils.isBlank(changedAttributeName) &&
+                Utils.isBlank(authorName) &&
+                changeType == null;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof VocabularyContentChangeFilterDto that)) return false;
-        return Objects.equals(termName, that.termName) &&
+        if (!(o instanceof ChangeRecordFilterDto that)) return false;
+        return Objects.equals(assetLabel, that.assetLabel) &&
                 Objects.equals(changedAttributeName, that.changedAttributeName) &&
                 Objects.equals(authorName, that.authorName) &&
                 Objects.equals(changeType, that.changeType);
@@ -56,6 +70,6 @@ public class VocabularyContentChangeFilterDto {
 
     @Override
     public int hashCode() {
-        return Objects.hash(termName, changedAttributeName, authorName, changeType);
+        return Objects.hash(assetLabel, changedAttributeName, authorName, changeType);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/filter/VocabularyContentChangeFilterDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/filter/VocabularyContentChangeFilterDto.java
@@ -1,15 +1,16 @@
 package cz.cvut.kbss.termit.dto.filter;
 
 import java.net.URI;
+import java.util.Objects;
 
 /**
  * Represents parameters for filtering vocabulary content changes.
  */
 public class VocabularyContentChangeFilterDto {
-    private String termName;
-    private String changedAttributeName;
-    private String authorName;
-    private URI changeType;
+    private String termName = "";
+    private String changedAttributeName = "";
+    private String authorName = "";
+    private URI changeType = null;
 
     public String getTermName() {
         return termName;
@@ -41,5 +42,20 @@ public class VocabularyContentChangeFilterDto {
 
     public void setChangeType(URI changeType) {
         this.changeType = changeType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof VocabularyContentChangeFilterDto that)) return false;
+        return Objects.equals(termName, that.termName) &&
+                Objects.equals(changedAttributeName, that.changedAttributeName) &&
+                Objects.equals(authorName, that.authorName) &&
+                Objects.equals(changeType, that.changeType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(termName, changedAttributeName, authorName, changeType);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/filter/VocabularyContentChangeFilterDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/filter/VocabularyContentChangeFilterDto.java
@@ -1,0 +1,45 @@
+package cz.cvut.kbss.termit.dto.filter;
+
+import java.net.URI;
+
+/**
+ * Represents parameters for filtering vocabulary content changes.
+ */
+public class VocabularyContentChangeFilterDto {
+    private String termName;
+    private String changedAttributeName;
+    private String authorName;
+    private URI changeType;
+
+    public String getTermName() {
+        return termName;
+    }
+
+    public void setTermName(String termName) {
+        this.termName = termName;
+    }
+
+    public String getChangedAttributeName() {
+        return changedAttributeName;
+    }
+
+    public void setChangedAttributeName(String changedAttributeName) {
+        this.changedAttributeName = changedAttributeName;
+    }
+
+    public String getAuthorName() {
+        return authorName;
+    }
+
+    public void setAuthorName(String authorName) {
+        this.authorName = authorName;
+    }
+
+    public URI getChangeType() {
+        return changeType;
+    }
+
+    public void setChangeType(URI changeType) {
+        this.changeType = changeType;
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -91,8 +91,8 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
     @Override
     public Optional<Term> find(URI id) {
         try {
-            final Optional<Term> result = Optional.ofNullable(
-                    em.find(Term.class, id, descriptorFactory.termDescriptor(resolveVocabularyId(id))));
+            final Optional<Term> result = resolveVocabularyId(id).map(vocabulary ->
+                    em.find(Term.class, id, descriptorFactory.termDescriptor(vocabulary)));
             result.ifPresent(this::postLoad);
             return result;
         } catch (RuntimeException e) {
@@ -100,14 +100,14 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
         }
     }
 
-    private URI resolveVocabularyId(URI termId) {
+    private Optional<URI> resolveVocabularyId(URI termId) {
         try {
-            return em.createNativeQuery("SELECT DISTINCT ?v WHERE { ?t ?inVocabulary ?v . }", URI.class)
+            return Optional.of(em.createNativeQuery("SELECT DISTINCT ?v WHERE { ?t ?inVocabulary ?v . }", URI.class)
                      .setParameter("t", termId)
                      .setParameter("inVocabulary", TERM_FROM_VOCABULARY)
-                     .getSingleResult();
+                     .getSingleResult());
         } catch (NoResultException | NoUniqueResultException e) {
-            throw new PersistenceException("Unable to resolve term vocabulary.", e);
+            return Optional.empty();
         }
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
@@ -455,7 +455,7 @@ public class VocabularyDao extends BaseAssetDao<Vocabulary>
                             BIND(?attributeName as ?changedAttributeNameVal)
                             FILTER (!BOUND(?termNameVal) || CONTAINS(LCASE(?label), LCASE(?termNameVal)))
                             FILTER (!BOUND(?authorNameVal) || CONTAINS(LCASE(?authorFullName), LCASE(?authorNameVal)))
-                            FILTER (!BOUND(?changedAttributeName) || !BOUND(?changedAttributeNameVal) || CONTAINS(LCASE(?changedAttributeName), LCASE(?changedAttributeName)))
+                            FILTER (!BOUND(?changedAttributeNameVal) || CONTAINS(LCASE(?changedAttributeName), LCASE(?changedAttributeNameVal)))
                          } ORDER BY DESC(?timestamp) ?attribute
                          """, AbstractChangeRecord.class)
                        .setParameter("changeContext", changeTrackingContextResolver.resolveChangeTrackingContext(vocabulary))

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
@@ -428,9 +428,7 @@ public class VocabularyDao extends BaseAssetDao<Vocabulary>
                              BIND(CONCAT(?firstName, " ", ?lastName) as ?authorFullName)
                              OPTIONAL {
                                 ?record ?hasChangedAttribute ?attribute .
-                                OPTIONAL {
-                                    ?attribute ?hasRdfsLabel ?changedAttributeName .
-                                }
+                                ?attribute ?hasRdfsLabel ?changedAttributeName .
                              }
                              OPTIONAL {
                                 ?term ?inVocabulary ?vocabulary ;
@@ -442,10 +440,10 @@ public class VocabularyDao extends BaseAssetDao<Vocabulary>
                              }
                              BIND(?termName as ?termNameVal)
                              BIND(?authorName as ?authorNameVal)
-                             BIND(?changedAttributeName as ?changedAttributeNameVal)
-                             FILTER (!BOUND(?termNameVal) || CONTAINS(LCASE(?label), LCASE(?termName)))
-                             FILTER (!BOUND(?authorNameVal) || CONTAINS(LCASE(?authorFullName), LCASE(?authorName)))
-                             FILTER (!BOUND(?changedAttributeName) || !BOUND(?changedAttributeNameVal) || CONTAINS(LCASE(?changedAttributeName), LCASE(?attributeName)))
+                             BIND(?attributeName as ?changedAttributeNameVal)
+                             FILTER (!BOUND(?termNameVal) || CONTAINS(LCASE(?label), LCASE(?termNameVal)))
+                             FILTER (!BOUND(?authorNameVal) || CONTAINS(LCASE(?authorFullName), LCASE(?authorNameVal)))
+                             FILTER (!BOUND(?changedAttributeName) || !BOUND(?changedAttributeNameVal) || CONTAINS(LCASE(?changedAttributeName), LCASE(?changedAttributeName)))
                          } ORDER BY DESC(?timestamp) ?attribute
                          """, AbstractChangeRecord.class)
                        .setParameter("changeContext", changeTrackingContextResolver.resolveChangeTrackingContext(vocabulary))

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -99,7 +99,18 @@ public class ChangeRecordDao {
                             ?record ?hasChangedEntity ?asset ;
                                 ?hasTime ?timestamp ;
                                 ?hasAuthor ?author .
-                            ?asset a ?assetType .
+""" + /* Find an asset type if it is known (deleted assets does not have a type */ """
+                            
+                            OPTIONAL {
+                                ?asset a ?assetType
+                            }
+                            OPTIONAL {
+                                ?asset a ?assetTypeVal .
+                                BIND(true as ?isAssetType)
+                            }
+""" + /* filter assets without a type (deleted) or with a matching type */ """
+                            BIND(?assetTypeVal as ?assetTypeVar)
+                            FILTER(!BOUND(?assetType) || !BOUND(?assetTypeVar) || BOUND(?isAssetType))
 """ + /* Get author's name */ """
                             ?author ?hasFirstName ?firstName ;
                                 ?hasLastName ?lastName .
@@ -124,8 +135,8 @@ public class ChangeRecordDao {
                             OPTIONAL {
                                 FILTER(!BOUND(?label)) .
                                 ?deleteRecord a ?deleteRecordType;
-                                    ?hasChangedEntity ?term;
-                                    ?hasRdfsLabel ?label.
+                                    ?hasChangedEntity ?asset;
+                                    ?hasRdfsLabel ?label .
                             }
                             BIND(?assetLabelValue as ?assetLabel)
                             BIND(?authorNameValue as ?authorName)
@@ -155,7 +166,7 @@ public class ChangeRecordDao {
         if(asset.isPresent() && asset.get().getUri() != null) {
             query = query.setParameter("asset", asset.get().getUri());
         } else if (assetType.isPresent()) {
-            query = query.setParameter("assetType", assetType.get());
+            query = query.setParameter("assetTypeVal", assetType.get());
         }
         
 

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -107,9 +107,8 @@ public class ChangeRecordDao {
                                     BIND(true as ?isAssetType)
                                 }
                             }
-                            FILTER(!BOUND(?assetType) || ?isAssetType)
 """ + /* filter assets without a type (deleted) or with a matching type */ """
-                            
+                            FILTER(!BOUND(?assetType) || ?isAssetType)
 """ + /* Get author's name */ """
                             ?author ?hasFirstName ?firstName ;
                                 ?hasLastName ?lastName .

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -20,18 +20,25 @@ package cz.cvut.kbss.termit.persistence.dao.changetracking;
 import cz.cvut.kbss.jopa.model.EntityManager;
 import cz.cvut.kbss.jopa.model.descriptors.Descriptor;
 import cz.cvut.kbss.jopa.model.descriptors.EntityDescriptor;
+import cz.cvut.kbss.jopa.model.query.TypedQuery;
+import cz.cvut.kbss.jopa.vocabulary.RDFS;
+import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.exception.PersistenceException;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.User;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.util.HasIdentifier;
+import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.Vocabulary;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 @Repository
@@ -66,13 +73,120 @@ public class ChangeRecordDao {
         }
     }
 
+    public List<AbstractChangeRecord> findAll(Asset<?> asset, ChangeRecordFilterDto filterDto) {
+        if (filterDto.isEmpty()) {
+            // there is nothing to filter, simple query can be used
+            return findAll(asset);
+        }
+        return findAllFiltered(contextResolver.resolveChangeTrackingContext(asset), filterDto, Optional.of(asset), Optional.empty(), Pageable.unpaged());
+    }
+
+    /**
+     * @param changeContext the context of change records
+     * @param filter filter parameters
+     * @param asset if present, only changes of the asset will be returned
+     * @param assetType if present, only changes related to this asset type will be returned.
+     */
+    public List<AbstractChangeRecord> findAllFiltered(URI changeContext, ChangeRecordFilterDto filter, Optional<Asset<?>> asset, Optional<URI> assetType, Pageable pageable) {
+        TypedQuery<AbstractChangeRecord> query = em.createNativeQuery("""
+                         SELECT DISTINCT ?record WHERE {
+""" + /* Select anything from change context */ """
+                            GRAPH ?changeContext {
+                                ?record a ?changeRecord .
+                            }
+""" + /* The record should be a subclass of changeType ("zmena") and have timestamp and author */ """
+                            ?changeRecord ?subClassOf+ ?changeType .
+                            ?record ?hasChangedEntity ?asset ;
+                                ?hasTime ?timestamp ;
+                                ?hasAuthor ?author .
+                            ?asset a ?assetType .
+""" + /* Get author's name */ """
+                            ?author ?hasFirstName ?firstName ;
+                                ?hasLastName ?lastName .
+                            BIND(CONCAT(?firstName, " ", ?lastName) as ?authorFullName)
+""" + /* When its update record, there will be a changed attribute */ """
+                            OPTIONAL {
+                               ?record ?hasChangedAttribute ?attribute .
+                               ?attribute ?hasRdfsLabel ?changedAttributeLabel .
+                            }
+""" + /* Get asset's name (but the asset might have been already deleted) */ """
+                            OPTIONAL {
+                               ?asset ?hasLabel ?label .
+                            }
+                            OPTIONAL {
+                                ?asset ?hasRdfsLabel ?label .
+                            }
+""" + /* then try to get the label from (delete) record */ """
+                            OPTIONAL {
+                               ?record ?hasRdfsLabel ?label .
+                            }
+""" + /* When label is still not bound, the term was probably deleted, find the delete record and get the label from it */ """
+                            OPTIONAL {
+                                FILTER(!BOUND(?label)) .
+                                ?deleteRecord a ?deleteRecordType;
+                                    ?hasChangedEntity ?term;
+                                    ?hasRdfsLabel ?label.
+                            }
+                            BIND(?assetLabelValue as ?assetLabel)
+                            BIND(?authorNameValue as ?authorName)
+                            BIND(?attributeNameValue as ?changedAttributeName)
+                            FILTER (!BOUND(?assetLabel) || CONTAINS(LCASE(?label), LCASE(?assetLabel)))
+                            FILTER (!BOUND(?authorName) || CONTAINS(LCASE(?authorFullName), LCASE(?authorName)))
+                            FILTER (!BOUND(?changedAttributeName) || CONTAINS(LCASE(?changedAttributeLabel), LCASE(?changedAttributeName)))
+                         } ORDER BY DESC(?timestamp) ?attribute
+                         """, AbstractChangeRecord.class)
+                                                   .setParameter("changeContext", changeContext)
+                                                   .setParameter("subClassOf", URI.create(RDFS.SUB_CLASS_OF))
+                                                    .setParameter("changeType", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_c_zmena))
+                                                   .setParameter("hasChangedEntity", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_zmenenou_entitu))
+                                                   .setParameter("hasTime", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_datum_a_cas_modifikace))
+                                                   .setParameter("hasAuthor", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_editora)) // record has author
+                                                   .setParameter("hasFirstName", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_krestni_jmeno))
+                                                   .setParameter("hasLastName", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_prijmeni))
+                                                   // Optional - update change record
+                                                   .setParameter("hasChangedAttribute", URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_p_ma_zmeneny_atribut))
+                                                   .setParameter("hasRdfsLabel", URI.create(RDFS.LABEL))
+                                                   // Optional -
+                                                   .setParameter("hasLabel", URI.create(SKOS.PREF_LABEL))
+
+                                                   // Optional asset label
+                                                   .setParameter("deleteRecordType", Vocabulary.s_c_smazani_entity);
+
+        if(asset.isPresent() && asset.get().getUri() != null) {
+            query = query.setParameter("asset", asset.get().getUri());
+        } else if (assetType.isPresent()) {
+            query = query.setParameter("assetType", assetType.get());
+        }
+        
+
+        if(!Utils.isBlank(filter.getAssetLabel())) {
+            query = query.setParameter("assetLabelValue", filter.getAssetLabel().trim());
+        }
+        if (!Utils.isBlank(filter.getAuthorName())) {
+            query = query.setParameter("authorNameValue", filter.getAuthorName().trim());
+        }
+        if (filter.getChangeType() != null) {
+            query = query.setParameter("changeRecord", filter.getChangeType());
+        }
+        if (!Utils.isBlank(filter.getChangedAttributeName())) {
+            query = query.setParameter("attributeNameValue", filter.getChangedAttributeName().trim());
+        }
+
+        if(pageable.isUnpaged()) {
+            return query.getResultList();
+        }
+
+        return query.setFirstResult((int) pageable.getOffset())
+                    .setMaxResults(pageable.getPageSize()).getResultList();
+    }
+
     /**
      * Finds all change records to the specified asset.
      *
      * @param asset The changed asset
      * @return List of change records ordered by timestamp (descending)
      */
-    public List<AbstractChangeRecord> findAll(HasIdentifier asset) {
+    public List<AbstractChangeRecord> findAll(Asset<?> asset) {
         Objects.requireNonNull(asset);
         try {
             final Descriptor descriptor = new EntityDescriptor();

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDao.java
@@ -76,8 +76,8 @@ public class ChangeRecordDao {
     /**
      * Finds all change records related to the specified asset.
      *
-     * @param asset the asset
-     * @return list of change records
+     * @param asset The changed asset
+     * @return List of change records ordered by timestamp (descending)
      */
     public List<AbstractChangeRecord> findAll(Asset<?> asset) {
         return findAll(asset, new ChangeRecordFilterDto());

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -361,7 +361,7 @@ public class ResourceController extends BaseController {
                           required = false) Optional<String> namespace) {
         final Resource resource = resourceService
                 .getReference(resolveIdentifier(resourceNamespace(namespace), localName));
-        return resourceService.getChanges(resource, new ChangeRecordFilterDto()); // TODO: filter dto
+        return resourceService.getChanges(resource, new ChangeRecordFilterDto());
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -18,6 +18,7 @@
 package cz.cvut.kbss.termit.rest;
 
 import cz.cvut.kbss.jsonld.JsonLd;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.model.TextAnalysisRecord;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
@@ -360,7 +361,7 @@ public class ResourceController extends BaseController {
                           required = false) Optional<String> namespace) {
         final Resource resource = resourceService
                 .getReference(resolveIdentifier(resourceNamespace(namespace), localName));
-        return resourceService.getChanges(resource);
+        return resourceService.getChanges(resource, new ChangeRecordFilterDto()); // TODO: filter dto
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -18,6 +18,7 @@
 package cz.cvut.kbss.termit.rest;
 
 import cz.cvut.kbss.jsonld.JsonLd;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.model.Term;
@@ -699,7 +700,7 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
             @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        return termService.getChanges(termService.findRequired(termUri));
+        return termService.getChanges(termService.findRequired(termUri), new ChangeRecordFilterDto()); // TODO: filter dto
     }
 
     /**
@@ -722,9 +723,21 @@ public class TermController extends BaseController {
                                                  @PathVariable String localName,
                                                  @Parameter(description = ApiDoc.ID_STANDALONE_NAMESPACE_DESCRIPTION,
                                                             example = ApiDoc.ID_STANDALONE_NAMESPACE_EXAMPLE)
-                                                 @RequestParam(name = QueryParams.NAMESPACE) String namespace) {
+                                                 @RequestParam(name = QueryParams.NAMESPACE) String namespace,
+                                                 @Parameter(description = "Change type used for filtering.")
+                                                 @RequestParam(name = "type", required = false) URI changeType,
+                                                 @Parameter(description = "Author name used for filtering.")
+                                                 @RequestParam(name = "author", required = false,
+                                                               defaultValue = "") String authorName,
+                                                 @Parameter(description = "Changed attribute name used for filtering.")
+                                                 @RequestParam(name = "attribute", required = false,
+                                                               defaultValue = "") String changedAttributeName) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
-        return termService.getChanges(termService.findRequired(termUri));
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
+        filter.setChangeType(changeType);
+        filter.setAuthorName(authorName);
+        filter.setChangedAttributeName(changedAttributeName);
+        return termService.getChanges(termService.findRequired(termUri), filter);
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -700,16 +700,13 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
             @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
             @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGE_TYPE_DESCRIPTION)
-            @RequestParam(name = "type", required = false) URI changeType,
+            @RequestParam(name = "changeType", required = false) URI changeType,
             @Parameter(description = ChangeRecordFilterDto.ApiDoc.AUTHOR_NAME_DESCRIPTION)
             @RequestParam(name = "author", required = false, defaultValue = "") String authorName,
             @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGED_ATTRIBUTE_DESCRIPTION)
             @RequestParam(name = "attribute", required = false, defaultValue = "") String changedAttributeName) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
-        filterDto.setChangeType(changeType);
-        filterDto.setAuthorName(authorName);
-        filterDto.setChangedAttributeName(changedAttributeName);
+        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto(changedAttributeName, authorName, changeType);
         return termService.getChanges(termService.findRequired(termUri), filterDto);
     }
 
@@ -734,19 +731,16 @@ public class TermController extends BaseController {
                                                  @Parameter(description = ApiDoc.ID_STANDALONE_NAMESPACE_DESCRIPTION,
                                                             example = ApiDoc.ID_STANDALONE_NAMESPACE_EXAMPLE)
                                                  @RequestParam(name = QueryParams.NAMESPACE) String namespace,
-                                                 @Parameter(description = "Change type used for filtering.")
-                                                 @RequestParam(name = "type", required = false) URI changeType,
-                                                 @Parameter(description = "Author name used for filtering.")
+                                                 @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGE_TYPE_DESCRIPTION)
+                                                 @RequestParam(name = "changeType", required = false) URI changeType,
+                                                 @Parameter(description = ChangeRecordFilterDto.ApiDoc.AUTHOR_NAME_DESCRIPTION)
                                                  @RequestParam(name = "author", required = false,
                                                                defaultValue = "") String authorName,
-                                                 @Parameter(description = "Changed attribute name used for filtering.")
+                                                 @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGED_ATTRIBUTE_DESCRIPTION)
                                                  @RequestParam(name = "attribute", required = false,
                                                                defaultValue = "") String changedAttributeName) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
-        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
-        filter.setChangeType(changeType);
-        filter.setAuthorName(authorName);
-        filter.setChangedAttributeName(changedAttributeName);
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto(changedAttributeName, authorName, changeType);
         return termService.getChanges(termService.findRequired(termUri), filter);
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -698,9 +698,19 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_TERM_LOCAL_NAME_DESCRIPTION, example = ApiDoc.ID_TERM_LOCAL_NAME_EXAMPLE)
             @PathVariable String termLocalName,
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
-            @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace) {
+            @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGE_TYPE_DESCRIPTION)
+            @RequestParam(name = "type", required = false) URI changeType,
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.AUTHOR_NAME_DESCRIPTION)
+            @RequestParam(name = "author", required = false, defaultValue = "") String authorName,
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGED_ATTRIBUTE_DESCRIPTION)
+            @RequestParam(name = "attribute", required = false, defaultValue = "") String changedAttributeName) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        return termService.getChanges(termService.findRequired(termUri), new ChangeRecordFilterDto()); // TODO: filter dto
+        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
+        filterDto.setChangeType(changeType);
+        filterDto.setAuthorName(authorName);
+        filterDto.setChangedAttributeName(changedAttributeName);
+        return termService.getChanges(termService.findRequired(termUri), filterDto);
     }
 
     /**
@@ -708,7 +718,7 @@ public class TermController extends BaseController {
      * <p>
      * This is a convenience method to allow access without using the Term's parent Vocabulary.
      *
-     * @see #getHistory(String, String, Optional)
+     * @see #getHistory
      */
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
                description = "Gets a list of changes made to metadata of the term with the specified identifier.")

--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -272,10 +272,7 @@ public class VocabularyController extends BaseController {
             @RequestParam(name = "attribute", required = false, defaultValue = "") String changedAttributeName) {
         final Vocabulary vocabulary = vocabularyService.getReference(
                 resolveVocabularyUri(localName, namespace));
-        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
-        filterDto.setChangeType(changeType);
-        filterDto.setAuthorName(authorName);
-        filterDto.setChangedAttributeName(changedAttributeName);
+        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto(changedAttributeName, authorName, changeType);
         return vocabularyService.getChanges(vocabulary, filterDto);
     }
 
@@ -330,11 +327,7 @@ public class VocabularyController extends BaseController {
                     name = Constants.QueryParams.PAGE, required = false, defaultValue = DEFAULT_PAGE) Integer pageNo) {
         final Pageable pageReq = createPageRequest(pageSize, pageNo);
         final Vocabulary vocabulary = vocabularyService.getReference(resolveVocabularyUri(localName, namespace));
-        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
-        filter.setAssetLabel(termName);
-        filter.setChangeType(changeType);
-        filter.setAuthorName(authorName);
-        filter.setChangedAttributeName(changedAttributeName);
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto(termName, changedAttributeName, authorName, changeType);
         return vocabularyService.getDetailedHistoryOfContent(vocabulary, filter, pageReq);
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -22,6 +22,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
+import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.acl.AccessControlRecord;
@@ -301,6 +302,15 @@ public class VocabularyController extends BaseController {
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION,
                        example = ApiDoc.ID_NAMESPACE_EXAMPLE) @RequestParam(name = QueryParams.NAMESPACE,
                                                                             required = false) Optional<String> namespace,
+            @Parameter(description = "Term name to be used in filtering.")
+            @RequestParam(name = "term", required = false, defaultValue = "") String termName,
+            @Parameter(description = "Change type to be used in filtering.")
+            @RequestParam(name = "type", required = false) URI changeType,
+            @Parameter(description = "Author name to be used in filtering.")
+            @RequestParam(name = "author", required = false, defaultValue = "") String authorName,
+            @Parameter(description = "Changed attribute name to be used in filtering.")
+            @RequestParam(name = "attribute", required = false, defaultValue = "") String changedAttributeName,
+
             @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION) @RequestParam(
                     name = Constants.QueryParams.PAGE_SIZE, required = false,
                     defaultValue = DEFAULT_PAGE_SIZE) Integer pageSize,
@@ -308,7 +318,12 @@ public class VocabularyController extends BaseController {
                     name = Constants.QueryParams.PAGE, required = false, defaultValue = DEFAULT_PAGE) Integer pageNo) {
         final Pageable pageReq = createPageRequest(pageSize, pageNo);
         final Vocabulary vocabulary = vocabularyService.getReference(resolveVocabularyUri(localName, namespace));
-        return vocabularyService.getDetailedHistoryOfContent(vocabulary, pageReq);
+        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
+        filter.setTermName(termName);
+        filter.setChangeType(changeType);
+        filter.setAuthorName(authorName);
+        filter.setChangedAttributeName(changedAttributeName);
+        return vocabularyService.getDetailedHistoryOfContent(vocabulary, filter, pageReq);
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},

--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -263,10 +263,20 @@ public class VocabularyController extends BaseController {
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION,
                        example = ApiDoc.ID_NAMESPACE_EXAMPLE)
             @RequestParam(name = QueryParams.NAMESPACE,
-                          required = false) Optional<String> namespace) {
+                          required = false) Optional<String> namespace,
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGE_TYPE_DESCRIPTION)
+            @RequestParam(name = "type", required = false) URI changeType,
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.AUTHOR_NAME_DESCRIPTION)
+            @RequestParam(name = "author", required = false, defaultValue = "") String authorName,
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGED_ATTRIBUTE_DESCRIPTION)
+            @RequestParam(name = "attribute", required = false, defaultValue = "") String changedAttributeName) {
         final Vocabulary vocabulary = vocabularyService.getReference(
                 resolveVocabularyUri(localName, namespace));
-        return vocabularyService.getChanges(vocabulary, new ChangeRecordFilterDto()); // TODO: filter dto
+        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
+        filterDto.setChangeType(changeType);
+        filterDto.setAuthorName(authorName);
+        filterDto.setChangedAttributeName(changedAttributeName);
+        return vocabularyService.getChanges(vocabulary, filterDto);
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -302,15 +312,15 @@ public class VocabularyController extends BaseController {
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION,
                        example = ApiDoc.ID_NAMESPACE_EXAMPLE) @RequestParam(name = QueryParams.NAMESPACE,
                                                                             required = false) Optional<String> namespace,
-            @Parameter(description = "Term name used for filtering.") @RequestParam(name = "term",
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.TERM_NAME_DESCRIPTION) @RequestParam(name = "term",
                                                                                          required = false,
                                                                                          defaultValue = "") String termName,
-            @Parameter(description = "Change type used for filtering.") @RequestParam(name = "type",
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGE_TYPE_DESCRIPTION) @RequestParam(name = "type",
                                                                                            required = false) URI changeType,
-            @Parameter(description = "Author name used for filtering.") @RequestParam(name = "author",
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.AUTHOR_NAME_DESCRIPTION) @RequestParam(name = "author",
                                                                                            required = false,
                                                                                            defaultValue = "") String authorName,
-            @Parameter(description = "Changed attribute name used for filtering.") @RequestParam(
+            @Parameter(description = ChangeRecordFilterDto.ApiDoc.CHANGED_ATTRIBUTE_DESCRIPTION) @RequestParam(
                     name = "attribute", required = false, defaultValue = "") String changedAttributeName,
 
             @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION) @RequestParam(

--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -22,7 +22,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
-import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.acl.AccessControlRecord;
@@ -266,7 +266,7 @@ public class VocabularyController extends BaseController {
                           required = false) Optional<String> namespace) {
         final Vocabulary vocabulary = vocabularyService.getReference(
                 resolveVocabularyUri(localName, namespace));
-        return vocabularyService.getChanges(vocabulary);
+        return vocabularyService.getChanges(vocabulary, new ChangeRecordFilterDto()); // TODO: filter dto
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -297,34 +297,31 @@ public class VocabularyController extends BaseController {
     @GetMapping(value = "/{localName}/history-of-content/detail",
                 produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
     public List<AbstractChangeRecord> getDetailedHistoryOfContent(
-            @Parameter(description = ApiDoc.ID_LOCAL_NAME_DESCRIPTION, example = ApiDoc.ID_LOCAL_NAME_EXAMPLE)
-            @PathVariable
-            String localName,
-            @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
-            @RequestParam(name = QueryParams.NAMESPACE, required = false)
-            Optional<String> namespace,
-            @Parameter(description = "Term name to be used in filtering.")
-            @RequestParam(name = "term", required = false, defaultValue = "")
-            String termName,
-            @Parameter(description = "Change type to be used in filtering.")
-            @RequestParam(name = "type", required = false)
-            URI changeType,
-            @Parameter(description = "Author name to be used in filtering.")
-            @RequestParam(name = "author", required = false, defaultValue = "")
-            String authorName,
-            @Parameter(description = "Changed attribute name to be used in filtering.")
-            @RequestParam(name = "attribute", required = false, defaultValue = "")
-            String changedAttributeName,
-            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
-            @RequestParam(name = Constants.QueryParams.PAGE_SIZE, required = false, defaultValue = DEFAULT_PAGE_SIZE)
-            Integer pageSize,
-            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
-            @RequestParam(name = Constants.QueryParams.PAGE, required = false, defaultValue = DEFAULT_PAGE)
-            Integer pageNo) {
+            @Parameter(description = ApiDoc.ID_LOCAL_NAME_DESCRIPTION,
+                       example = ApiDoc.ID_LOCAL_NAME_EXAMPLE) @PathVariable String localName,
+            @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION,
+                       example = ApiDoc.ID_NAMESPACE_EXAMPLE) @RequestParam(name = QueryParams.NAMESPACE,
+                                                                            required = false) Optional<String> namespace,
+            @Parameter(description = "Term name used for filtering.") @RequestParam(name = "term",
+                                                                                         required = false,
+                                                                                         defaultValue = "") String termName,
+            @Parameter(description = "Change type used for filtering.") @RequestParam(name = "type",
+                                                                                           required = false) URI changeType,
+            @Parameter(description = "Author name used for filtering.") @RequestParam(name = "author",
+                                                                                           required = false,
+                                                                                           defaultValue = "") String authorName,
+            @Parameter(description = "Changed attribute name used for filtering.") @RequestParam(
+                    name = "attribute", required = false, defaultValue = "") String changedAttributeName,
+
+            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION) @RequestParam(
+                    name = Constants.QueryParams.PAGE_SIZE, required = false,
+                    defaultValue = DEFAULT_PAGE_SIZE) Integer pageSize,
+            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION) @RequestParam(
+                    name = Constants.QueryParams.PAGE, required = false, defaultValue = DEFAULT_PAGE) Integer pageNo) {
         final Pageable pageReq = createPageRequest(pageSize, pageNo);
         final Vocabulary vocabulary = vocabularyService.getReference(resolveVocabularyUri(localName, namespace));
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
-        filter.setTermName(termName);
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
+        filter.setAssetLabel(termName);
         filter.setChangeType(changeType);
         filter.setAuthorName(authorName);
         filter.setChangedAttributeName(changedAttributeName);

--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -297,25 +297,30 @@ public class VocabularyController extends BaseController {
     @GetMapping(value = "/{localName}/history-of-content/detail",
                 produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
     public List<AbstractChangeRecord> getDetailedHistoryOfContent(
-            @Parameter(description = ApiDoc.ID_LOCAL_NAME_DESCRIPTION,
-                       example = ApiDoc.ID_LOCAL_NAME_EXAMPLE) @PathVariable String localName,
-            @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION,
-                       example = ApiDoc.ID_NAMESPACE_EXAMPLE) @RequestParam(name = QueryParams.NAMESPACE,
-                                                                            required = false) Optional<String> namespace,
+            @Parameter(description = ApiDoc.ID_LOCAL_NAME_DESCRIPTION, example = ApiDoc.ID_LOCAL_NAME_EXAMPLE)
+            @PathVariable
+            String localName,
+            @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
+            @RequestParam(name = QueryParams.NAMESPACE, required = false)
+            Optional<String> namespace,
             @Parameter(description = "Term name to be used in filtering.")
-            @RequestParam(name = "term", required = false, defaultValue = "") String termName,
+            @RequestParam(name = "term", required = false, defaultValue = "")
+            String termName,
             @Parameter(description = "Change type to be used in filtering.")
-            @RequestParam(name = "type", required = false) URI changeType,
+            @RequestParam(name = "type", required = false)
+            URI changeType,
             @Parameter(description = "Author name to be used in filtering.")
-            @RequestParam(name = "author", required = false, defaultValue = "") String authorName,
+            @RequestParam(name = "author", required = false, defaultValue = "")
+            String authorName,
             @Parameter(description = "Changed attribute name to be used in filtering.")
-            @RequestParam(name = "attribute", required = false, defaultValue = "") String changedAttributeName,
-
-            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION) @RequestParam(
-                    name = Constants.QueryParams.PAGE_SIZE, required = false,
-                    defaultValue = DEFAULT_PAGE_SIZE) Integer pageSize,
-            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION) @RequestParam(
-                    name = Constants.QueryParams.PAGE, required = false, defaultValue = DEFAULT_PAGE) Integer pageNo) {
+            @RequestParam(name = "attribute", required = false, defaultValue = "")
+            String changedAttributeName,
+            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
+            @RequestParam(name = Constants.QueryParams.PAGE_SIZE, required = false, defaultValue = DEFAULT_PAGE_SIZE)
+            Integer pageSize,
+            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
+            @RequestParam(name = Constants.QueryParams.PAGE, required = false, defaultValue = DEFAULT_PAGE)
+            Integer pageNo) {
         final Pageable pageReq = createPageRequest(pageSize, pageNo);
         final Vocabulary vocabulary = vocabularyService.getReference(resolveVocabularyUri(localName, namespace));
         final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -18,6 +18,7 @@
 package cz.cvut.kbss.termit.service.business;
 
 import cz.cvut.kbss.termit.asset.provenance.SupportsLastModification;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.event.DocumentRenameEvent;
 import cz.cvut.kbss.termit.event.FileRenameEvent;
 import cz.cvut.kbss.termit.event.VocabularyWillBeRemovedEvent;
@@ -369,8 +370,8 @@ public class ResourceService
     }
 
     @Override
-    public List<AbstractChangeRecord> getChanges(Resource asset) {
-        return changeRecordService.getChanges(asset);
+    public List<AbstractChangeRecord> getChanges(Resource asset, ChangeRecordFilterDto filterDto) {
+        return changeRecordService.getChanges(asset, filterDto);
     }
 
     @Override

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -20,6 +20,7 @@ package cz.cvut.kbss.termit.service.business;
 import cz.cvut.kbss.termit.dto.RdfsResource;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.assignment.TermOccurrences;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.exception.InvalidTermStateException;
 import cz.cvut.kbss.termit.exception.NotFoundException;
@@ -545,9 +546,9 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
     }
 
     @Override
-    public List<AbstractChangeRecord> getChanges(Term term) {
+    public List<AbstractChangeRecord> getChanges(Term term, ChangeRecordFilterDto filterDto) {
         Objects.requireNonNull(term);
-        return changeRecordService.getChanges(term);
+        return changeRecordService.getChanges(term, filterDto);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -22,7 +22,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
-import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.event.VocabularyContentModifiedEvent;
@@ -299,8 +299,8 @@ public class VocabularyService
     }
 
     @Override
-    public List<AbstractChangeRecord> getChanges(Vocabulary asset) {
-        return changeRecordService.getChanges(asset);
+    public List<AbstractChangeRecord> getChanges(Vocabulary asset, ChangeRecordFilterDto filterDto) {
+        return changeRecordService.getChanges(asset, filterDto);
     }
 
     /**
@@ -320,7 +320,7 @@ public class VocabularyService
      * @param pageReq Specification of the size and number of the page to return
      * @return List of change records, ordered by date in descending order
      */
-    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, VocabularyContentChangeFilterDto filter, Pageable pageReq) {
+    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, ChangeRecordFilterDto filter, Pageable pageReq) {
         return repositoryService.getDetailedHistoryOfContent(vocabulary, filter, pageReq);
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -22,6 +22,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
+import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.event.VocabularyContentModifiedEvent;
@@ -319,8 +320,8 @@ public class VocabularyService
      * @param pageReq Specification of the size and number of the page to return
      * @return List of change records, ordered by date in descending order
      */
-    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, Pageable pageReq) {
-        return repositoryService.getDetailedHistoryOfContent(vocabulary, pageReq);
+    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, VocabularyContentChangeFilterDto filter, Pageable pageReq) {
+        return repositoryService.getDetailedHistoryOfContent(vocabulary, filter, pageReq);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/changetracking/ChangeRecordProvider.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/changetracking/ChangeRecordProvider.java
@@ -17,8 +17,9 @@
  */
 package cz.cvut.kbss.termit.service.changetracking;
 
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
+import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
-import cz.cvut.kbss.termit.model.util.HasIdentifier;
 
 import java.util.List;
 
@@ -27,7 +28,17 @@ import java.util.List;
  *
  * @param <T> Type of asset to get changes for
  */
-public interface ChangeRecordProvider<T extends HasIdentifier> {
+public interface ChangeRecordProvider<T extends Asset<?>> {
+
+    /**
+     * Gets change records of the specified asset
+     * filtered by {@link ChangeRecordFilterDto}.
+     *
+     * @param asset Asset to find change records for
+     * @param filterDto Filter parameters
+     * @return List of change records, ordered by record timestamp in descending order
+     */
+    List<AbstractChangeRecord> getChanges(T asset, ChangeRecordFilterDto filterDto);
 
     /**
      * Gets change records of the specified asset.
@@ -35,5 +46,7 @@ public interface ChangeRecordProvider<T extends HasIdentifier> {
      * @param asset Asset to find change records for
      * @return List of change records, ordered by record timestamp in descending order
      */
-    List<AbstractChangeRecord> getChanges(T asset);
+    default List<AbstractChangeRecord> getChanges(T asset) {
+        return getChanges(asset, new ChangeRecordFilterDto());
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ChangeRecordService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ChangeRecordService.java
@@ -17,6 +17,8 @@
  */
 package cz.cvut.kbss.termit.service.repository;
 
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
+import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.User;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.util.HasIdentifier;
@@ -29,7 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 @Service
-public class ChangeRecordService implements ChangeRecordProvider<HasIdentifier> {
+public class ChangeRecordService implements ChangeRecordProvider<Asset<?>> {
 
     private final ChangeRecordDao changeRecordDao;
 
@@ -39,8 +41,8 @@ public class ChangeRecordService implements ChangeRecordProvider<HasIdentifier> 
     }
 
     @Override
-    public List<AbstractChangeRecord> getChanges(HasIdentifier asset) {
-        return changeRecordDao.findAll(asset);
+    public List<AbstractChangeRecord> getChanges(Asset<?> asset, ChangeRecordFilterDto filterDto) {
+        return changeRecordDao.findAll(asset, filterDto);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -21,6 +21,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.PrefixDeclaration;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
+import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.dto.mapper.DtoMapper;
 import cz.cvut.kbss.termit.exception.AssetRemovalException;
@@ -228,8 +229,8 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
      * @return List of change records, ordered by date in descending order
      */
     @Transactional(readOnly = true)
-    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, Pageable pageReq) {
-        return vocabularyDao.getDetailedHistoryOfContent(vocabulary, pageReq);
+    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, VocabularyContentChangeFilterDto filter, Pageable pageReq) {
+        return vocabularyDao.getDetailedHistoryOfContent(vocabulary, filter, pageReq);
     }
 
     @CacheEvict(allEntries = true)

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -21,7 +21,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.PrefixDeclaration;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
-import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.dto.mapper.DtoMapper;
 import cz.cvut.kbss.termit.exception.AssetRemovalException;
@@ -229,7 +229,7 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
      * @return List of change records, ordered by date in descending order
      */
     @Transactional(readOnly = true)
-    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, VocabularyContentChangeFilterDto filter, Pageable pageReq) {
+    public List<AbstractChangeRecord> getDetailedHistoryOfContent(Vocabulary vocabulary, ChangeRecordFilterDto filter, Pageable pageReq) {
         return vocabularyDao.getDetailedHistoryOfContent(vocabulary, filter, pageReq);
     }
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
@@ -82,6 +82,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -1393,5 +1394,13 @@ class TermDaoTest extends BaseTermDaoTestRunner {
         final Optional<Term> result = sut.find(term.getUri());
         assertTrue(result.isPresent());
         assertFalse(result.get().getProperties().containsKey(property));
+    }
+
+    @Test
+    void findByIdReturnsOptionalEmptyWhenTermDoesNotExists() {
+        final Term term = Generator.generateTermWithId(vocabulary.getUri());
+        // trying to find a non-existing term
+        final Optional<Term> empty = assertDoesNotThrow(()-> sut.find(term.getUri()));
+        assertTrue(empty.isEmpty());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -26,7 +26,7 @@ import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.PrefixDeclaration;
 import cz.cvut.kbss.termit.dto.RdfsStatement;
 import cz.cvut.kbss.termit.dto.Snapshot;
-import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.event.AssetPersistEvent;
@@ -978,7 +978,7 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             changeRecordDao.persist(deleteChangeRecord, termToRemove);
         });
 
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
         final int recordsCount = firstChanges.size() + termToRemoveChanges.size() + 1; // +1 for the delete record
         final Pageable pageable = Pageable.ofSize(recordsCount * 3);
         final List<AbstractChangeRecord> contentChanges = sut.getDetailedHistoryOfContent(vocabulary, filter, pageable);
@@ -1028,8 +1028,8 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             thirdChanges.forEach(r -> changeRecordDao.persist(r, thirdTerm));
         });
 
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
-        filter.setTermName(needle);
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
+        filter.setAssetLabel(needle);
 
         final int recordsCount = firstChanges.size() + secondChanges.size();
         final Pageable pageable = Pageable.ofSize(recordsCount * 2);
@@ -1083,8 +1083,8 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             termDao.remove(termToRemove);
         });
 
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
-        filter.setTermName(needle);
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
+        filter.setAssetLabel(needle);
 
         final int recordsCount = termToRemoveChanges.size() + 1; // +1 for the delete record
         final Pageable pageable = Pageable.ofSize(recordsCount * 2);
@@ -1142,7 +1142,7 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             secondChanges.forEach(r -> changeRecordDao.persist(r, secondTerm));
         });
 
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
         filter.setChangedAttributeName(changedAttributeName);
 
         final Pageable pageable = Pageable.ofSize(recordCount.get() * 2);
@@ -1193,7 +1193,7 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             secondChanges.forEach(r -> changeRecordDao.persist(r, secondTerm));
         });
 
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
         // full name without first two and last two characters
         filter.setAuthorName(anotherAuthor.getFullName().substring(2, anotherAuthor.getFullName().length() - 2));
 
@@ -1256,7 +1256,7 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             termDao.remove(secondTerm);
         });
 
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
         // full name without first two and last two characters
         filter.setChangeType(typeUri);
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -46,7 +46,6 @@ import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.model.util.EntityToOwlClassMapper;
 import cz.cvut.kbss.termit.persistence.context.DescriptorFactory;
 import cz.cvut.kbss.termit.persistence.dao.changetracking.ChangeRecordDao;
-import cz.cvut.kbss.termit.persistence.dao.changetracking.ChangeTrackingContextResolver;
 import cz.cvut.kbss.termit.util.Constants;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -117,9 +116,6 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
 
     @SpyBean
     private ChangeRecordDao changeRecordDao;
-
-    @SpyBean
-    private ChangeTrackingContextResolver changeTrackingContextResolver;
 
     private User author;
 
@@ -954,12 +950,10 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
         final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
         filterDto.setAuthorName("Name of the author");
 
-        doReturn(vocabulary.getUri()).when(changeTrackingContextResolver).resolveChangeTrackingContext(vocabulary);
         doReturn(records).when(changeRecordDao).findAllRelatedToType(vocabulary, filterDto, skosConcept, unpaged);
 
         sut.getDetailedHistoryOfContent(vocabulary, filterDto, unpaged);
 
-        verify(changeTrackingContextResolver).resolveChangeTrackingContext(vocabulary);
         verify(changeRecordDao).findAllRelatedToType(vocabulary, filterDto, skosConcept, unpaged);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Spy;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -1075,6 +1075,9 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
             termDao.persist(firstTerm, vocabulary);
             termDao.persist(termToRemove, vocabulary);
 
+            Generator.addTermInVocabularyRelationship(firstTerm, vocabulary.getUri(), em);
+            Generator.addTermInVocabularyRelationship(termToRemove, vocabulary.getUri(), em);
+
             firstChanges.forEach(r -> changeRecordDao.persist(r, firstTerm));
             termToRemoveChanges.forEach(r -> changeRecordDao.persist(r, termToRemove));
             changeRecordDao.persist(deleteChangeRecord, termToRemove);
@@ -1247,6 +1250,9 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
 
             termDao.persist(firstTerm, vocabulary);
             termDao.persist(secondTerm, vocabulary);
+
+            Generator.addTermInVocabularyRelationship(firstTerm, vocabulary.getUri(), em);
+            Generator.addTermInVocabularyRelationship(secondTerm, vocabulary.getUri(), em);
 
             firstChanges.forEach(r -> changeRecordDao.persist(r, firstTerm));
             secondChanges.forEach(r -> changeRecordDao.persist(r, secondTerm));

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -115,9 +115,6 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
     @Autowired
     private VocabularyDao sut;
 
-    @Autowired
-    private TermDao termDao;
-
     @SpyBean
     private ChangeRecordDao changeRecordDao;
 
@@ -952,17 +949,17 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
     void getDetailedHistoryOfContentCallsChangeRecordDaoWithFilter() {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         final List<AbstractChangeRecord> records = List.of();
-        final Optional<URI> skosConcept = Optional.of(URI.create(SKOS.CONCEPT));
+        final URI skosConcept = URI.create(SKOS.CONCEPT);
         final Pageable unpaged = Pageable.unpaged();
         final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
         filterDto.setAuthorName("Name of the author");
 
         doReturn(vocabulary.getUri()).when(changeTrackingContextResolver).resolveChangeTrackingContext(vocabulary);
-        doReturn(records).when(changeRecordDao).findAllFiltered(vocabulary.getUri(), filterDto, Optional.empty(), skosConcept, unpaged);
+        doReturn(records).when(changeRecordDao).findAllRelatedToType(vocabulary, filterDto, skosConcept, unpaged);
 
         sut.getDetailedHistoryOfContent(vocabulary, filterDto, unpaged);
 
         verify(changeTrackingContextResolver).resolveChangeTrackingContext(vocabulary);
-        verify(changeRecordDao).findAllFiltered(vocabulary.getUri(), filterDto, Optional.empty(), skosConcept, unpaged);
+        verify(changeRecordDao).findAllRelatedToType(vocabulary, filterDto, skosConcept, unpaged);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDaoTest.java
@@ -153,15 +153,15 @@ class ChangeRecordDaoTest extends BaseDaoTestRunner {
     void findAllReturnsChangeRecordsOrderedByTimestampDescending() {
         enableRdfsInference(em);
         final Term asset = Generator.generateTermWithId(vocabulary.getUri());
-        transactional(() -> {
-            em.persist(vocabulary);
-            em.persist(asset, persistDescriptor(vocabulary.getUri()));
-        });
         final List<AbstractChangeRecord> records = IntStream.range(0, 5).mapToObj(
                 i -> generateUpdateRecord(Instant.ofEpochMilli(System.currentTimeMillis() + i * 10000L),
                                           asset.getUri())).collect(Collectors.toList());
         final URI changeContext = contextResolver.resolveChangeTrackingContext(vocabulary);
-        transactional(() -> records.forEach(r -> em.persist(r, persistDescriptor(changeContext))));
+        transactional(() -> {
+            em.persist(vocabulary);
+            em.persist(asset, persistDescriptor(vocabulary.getUri()));
+            records.forEach(r -> em.persist(r, persistDescriptor(changeContext)));
+        });
 
         final List<AbstractChangeRecord> result = sut.findAll(asset);
         records.sort(Comparator.comparing(AbstractChangeRecord::getTimestamp).reversed());

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/changetracking/ChangeRecordDaoTest.java
@@ -132,7 +132,7 @@ class ChangeRecordDaoTest extends BaseDaoTestRunner {
             em.persist(asset, persistDescriptor(vocabulary.getUri()));
         });
         final List<AbstractChangeRecord> records = IntStream.range(0, 5).mapToObj(
-                i -> generateUpdateRecord(Instant.ofEpochMilli(System.currentTimeMillis() - i * 10000L),
+                i -> generateUpdateRecord(Utils.timestamp().minusSeconds(i * 10L),
                                           asset.getUri())).collect(Collectors.toList());
         final URI changeContext = contextResolver.resolveChangeTrackingContext(vocabulary);
         transactional(() -> records.forEach(r -> em.persist(r, persistDescriptor(changeContext))));
@@ -154,7 +154,7 @@ class ChangeRecordDaoTest extends BaseDaoTestRunner {
         enableRdfsInference(em);
         final Term asset = Generator.generateTermWithId(vocabulary.getUri());
         final List<AbstractChangeRecord> records = IntStream.range(0, 5).mapToObj(
-                i -> generateUpdateRecord(Instant.ofEpochMilli(System.currentTimeMillis() + i * 10000L),
+                i -> generateUpdateRecord(Utils.timestamp().plusSeconds(i * 10L),
                                           asset.getUri())).collect(Collectors.toList());
         final URI changeContext = contextResolver.resolveChangeTrackingContext(vocabulary);
         transactional(() -> {

--- a/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
@@ -19,6 +19,7 @@ package cz.cvut.kbss.termit.rest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import cz.cvut.kbss.jsonld.JsonLd;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.exception.NotFoundException;
@@ -396,7 +397,8 @@ class ResourceControllerTest extends BaseControllerTestRunner {
         when(identifierResolverMock.resolveIdentifier(RESOURCE_NAMESPACE, RESOURCE_NAME)).thenReturn(resource.getUri());
         when(resourceServiceMock.getReference(RESOURCE_URI)).thenReturn(resource);
         final List<AbstractChangeRecord> records = Collections.singletonList(Generator.generatePersistChange(resource));
-        when(resourceServiceMock.getChanges(resource)).thenReturn(records);
+        final ChangeRecordFilterDto emptyFilter = new ChangeRecordFilterDto();
+        when(resourceServiceMock.getChanges(resource, emptyFilter)).thenReturn(records);
 
         final MvcResult mvcResult = mockMvc
                 .perform(get(PATH + "/" + RESOURCE_NAME + "/history").param(QueryParams.NAMESPACE, RESOURCE_NAMESPACE))
@@ -406,7 +408,7 @@ class ResourceControllerTest extends BaseControllerTestRunner {
         });
         assertNotNull(result);
         assertEquals(records, result);
-        verify(resourceServiceMock).getChanges(resource);
+        verify(resourceServiceMock).getChanges(resource, emptyFilter);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/rest/TermControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/TermControllerTest.java
@@ -23,6 +23,7 @@ import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.jsonld.JsonLd;
 import cz.cvut.kbss.termit.dto.Snapshot;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
@@ -803,7 +804,8 @@ class TermControllerTest extends BaseControllerTestRunner {
         term.setUri(termUri);
         when(termServiceMock.findRequired(term.getUri())).thenReturn(term);
         final List<AbstractChangeRecord> records = generateChangeRecords(term);
-        when(termServiceMock.getChanges(term)).thenReturn(records);
+        final ChangeRecordFilterDto emptyFilter = new ChangeRecordFilterDto();
+        when(termServiceMock.getChanges(term, emptyFilter)).thenReturn(records);
 
         final MvcResult mvcResult = mockMvc
                 .perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME + "/history"))
@@ -812,6 +814,7 @@ class TermControllerTest extends BaseControllerTestRunner {
         });
         assertNotNull(result);
         assertEquals(records, result);
+        verify(termServiceMock).getChanges(term, emptyFilter);
     }
 
     private List<AbstractChangeRecord> generateChangeRecords(Term term) {
@@ -833,7 +836,8 @@ class TermControllerTest extends BaseControllerTestRunner {
         when(idResolverMock.resolveIdentifier(NAMESPACE, TERM_NAME)).thenReturn(termUri);
         when(termServiceMock.findRequired(termUri)).thenReturn(term);
         final List<AbstractChangeRecord> records = generateChangeRecords(term);
-        when(termServiceMock.getChanges(term)).thenReturn(records);
+        final ChangeRecordFilterDto emptyFilter = new ChangeRecordFilterDto();
+        when(termServiceMock.getChanges(term, emptyFilter)).thenReturn(records);
 
         final MvcResult mvcResult = mockMvc
                 .perform(get("/terms/" + TERM_NAME + "/history").param(QueryParams.NAMESPACE, NAMESPACE))
@@ -843,6 +847,7 @@ class TermControllerTest extends BaseControllerTestRunner {
         });
         assertNotNull(result);
         assertEquals(records, result);
+        verify(termServiceMock).getChanges(term, emptyFilter);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
@@ -73,17 +73,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static cz.cvut.kbss.termit.environment.util.ContainsSameEntities.containsSameEntities;
-import static cz.cvut.kbss.termit.util.Constants.DEFAULT_PAGE_SIZE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalToObject;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doReturn;

--- a/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
@@ -22,7 +22,7 @@ import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.termit.dto.AggregatedChangeInfo;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
-import cz.cvut.kbss.termit.dto.filter.VocabularyContentChangeFilterDto;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
@@ -431,7 +431,8 @@ class VocabularyControllerTest extends BaseControllerTestRunner {
         final Vocabulary vocabulary = generateVocabularyAndInitReferenceResolution();
         final List<AbstractChangeRecord> records =
                 Generator.generateChangeRecords(vocabulary, user);
-        when(serviceMock.getChanges(vocabulary)).thenReturn(records);
+        final ChangeRecordFilterDto emptyFilter = new ChangeRecordFilterDto();
+        when(serviceMock.getChanges(vocabulary, emptyFilter)).thenReturn(records);
 
         final MvcResult mvcResult =
                 mockMvc.perform(get(PATH + "/" + FRAGMENT + "/history")).andExpect(status().isOk())
@@ -441,7 +442,7 @@ class VocabularyControllerTest extends BaseControllerTestRunner {
                 });
         assertNotNull(result);
         assertEquals(records, result);
-        verify(serviceMock).getChanges(vocabulary);
+        verify(serviceMock).getChanges(vocabulary,emptyFilter);
     }
 
     @Test
@@ -653,7 +654,7 @@ class VocabularyControllerTest extends BaseControllerTestRunner {
         final Vocabulary vocabulary = generateVocabularyAndInitReferenceResolution();
         final Term term = Generator.generateTermWithId();
         final List<AbstractChangeRecord> changeRecords = IntStream.range(0, 5).mapToObj(i -> Generator.generateChangeRecords(term, user)).flatMap(List::stream).toList();
-        final VocabularyContentChangeFilterDto filter = new VocabularyContentChangeFilterDto();
+        final ChangeRecordFilterDto filter = new ChangeRecordFilterDto();
         final Pageable pageable = Pageable.ofSize(pageSize);
 
         doReturn(changeRecords).when(serviceMock).getDetailedHistoryOfContent(vocabulary, filter, pageable);

--- a/src/test/java/cz/cvut/kbss/termit/service/business/ResourceServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/ResourceServiceTest.java
@@ -17,6 +17,7 @@
  */
 package cz.cvut.kbss.termit.service.business;
 
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.event.DocumentRenameEvent;
@@ -426,9 +427,10 @@ class ResourceServiceTest {
     void getChangesLoadsChangeRecordsForSpecifiedAssetFromChangeRecordService() {
         final Resource resource = Generator.generateResourceWithId();
         final List<AbstractChangeRecord> records = Collections.singletonList(Generator.generatePersistChange(resource));
-        when(changeRecordService.getChanges(resource)).thenReturn(records);
+        final ChangeRecordFilterDto filterDto = new ChangeRecordFilterDto();
+        when(changeRecordService.getChanges(resource, filterDto)).thenReturn(records);
         assertEquals(records, sut.getChanges(resource));
-        verify(changeRecordService).getChanges(resource);
+        verify(changeRecordService).getChanges(resource, filterDto);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -21,6 +21,7 @@ import cz.cvut.kbss.jopa.model.MultilingualString;
 import cz.cvut.kbss.termit.dto.RdfsResource;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermOccurrences;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
@@ -396,7 +397,7 @@ class TermServiceTest {
     void getChangesRetrievesChangeRecordsFromChangeRecordService() {
         final Term asset = Generator.generateTermWithId();
         sut.getChanges(asset);
-        verify(changeRecordService).getChanges(asset);
+        verify(changeRecordService).getChanges(asset, new ChangeRecordFilterDto());
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
@@ -19,6 +19,7 @@ package cz.cvut.kbss.termit.service.business;
 
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
+import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.listing.VocabularyDto;
 import cz.cvut.kbss.termit.environment.Environment;
@@ -184,10 +185,11 @@ class VocabularyServiceTest {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         final List<AbstractChangeRecord> records = Generator.generateChangeRecords(vocabulary,
                                                                                    Generator.generateUserWithId());
-        when(changeRecordService.getChanges(vocabulary)).thenReturn(records);
+        final ChangeRecordFilterDto emptyFilter = new ChangeRecordFilterDto();
+        when(changeRecordService.getChanges(vocabulary, emptyFilter)).thenReturn(records);
         final List<AbstractChangeRecord> result = sut.getChanges(vocabulary);
         assertEquals(records, result);
-        verify(changeRecordService).getChanges(vocabulary);
+        verify(changeRecordService).getChanges(vocabulary, emptyFilter);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/ChangeRecordServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/ChangeRecordServiceTest.java
@@ -26,6 +26,7 @@ import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.changetracking.UpdateChangeRecord;
 import cz.cvut.kbss.termit.persistence.context.DescriptorFactory;
+import cz.cvut.kbss.termit.persistence.dao.changetracking.ChangeRecordDao;
 import cz.cvut.kbss.termit.service.BaseServiceTestRunner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,6 +51,9 @@ class ChangeRecordServiceTest extends BaseServiceTestRunner {
 
     @Autowired
     private ChangeRecordService sut;
+
+    @Autowired
+    private ChangeRecordDao dao;
 
     private User author;
 
@@ -84,7 +88,9 @@ class ChangeRecordServiceTest extends BaseServiceTestRunner {
             r.setTimestamp(Instant.ofEpochMilli(System.currentTimeMillis() - i * 10000L));
             return r;
         }).collect(Collectors.toList());
-        transactional(() -> records.forEach(em::persist));
+        transactional(() -> {
+            records.forEach(r -> dao.persist(r, asset));
+        });
         return records;
     }
 }


### PR DESCRIPTION
resolves kbss-cvut/termit-ui#520

Implements filtering in ChangeRecordDao.  
Several tests required modification because change records were stored in the vocabulary context instead of the change context.

