### PR TITLE
[Bug #314] ThrottledFuture exceptional callbacks

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
@@ -48,7 +48,7 @@ import cz.cvut.kbss.termit.persistence.validation.VocabularyContentValidator;
 import cz.cvut.kbss.termit.service.snapshot.SnapshotProvider;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Utils;
-import cz.cvut.kbss.termit.util.throttle.CacheableFuture;
+import cz.cvut.kbss.termit.util.throttle.ThrottledFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -366,7 +366,7 @@ public class VocabularyDao extends BaseAssetDao<Vocabulary>
     }
 
     @Transactional
-    public CacheableFuture<Collection<ValidationResult>> validateContents(URI vocabulary) {
+    public ThrottledFuture<Collection<ValidationResult>> validateContents(URI vocabulary) {
         final VocabularyContentValidator validator = context.getBean(VocabularyContentValidator.class);
         final Collection<URI> importClosure = getTransitivelyImportedVocabularies(vocabulary);
         importClosure.add(vocabulary);

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -46,8 +46,8 @@ import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.TypeAwareClasspathResource;
 import cz.cvut.kbss.termit.util.TypeAwareFileSystemResource;
 import cz.cvut.kbss.termit.util.TypeAwareResource;
-import cz.cvut.kbss.termit.util.throttle.CacheableFuture;
 import cz.cvut.kbss.termit.util.throttle.Throttle;
+import cz.cvut.kbss.termit.util.throttle.ThrottledFuture;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -384,7 +384,7 @@ public class VocabularyService
      *
      * @param vocabulary Vocabulary to validate
      */
-    public CacheableFuture<Collection<ValidationResult>> validateContents(URI vocabulary) {
+    public ThrottledFuture<Collection<ValidationResult>> validateContents(URI vocabulary) {
         return repositoryService.validateContents(vocabulary);
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -42,7 +42,7 @@ import cz.cvut.kbss.termit.service.snapshot.SnapshotProvider;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Constants;
 import cz.cvut.kbss.termit.util.Utils;
-import cz.cvut.kbss.termit.util.throttle.CacheableFuture;
+import cz.cvut.kbss.termit.util.throttle.ThrottledFuture;
 import cz.cvut.kbss.termit.workspace.EditableVocabularies;
 import jakarta.annotation.Nonnull;
 import jakarta.validation.Validator;
@@ -334,7 +334,7 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
         }
     }
 
-    public CacheableFuture<Collection<ValidationResult>> validateContents(URI vocabulary) {
+    public ThrottledFuture<Collection<ValidationResult>> validateContents(URI vocabulary) {
         return vocabularyDao.validateContents(vocabulary);
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/util/throttle/CacheableFuture.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/throttle/CacheableFuture.java
@@ -11,7 +11,7 @@ import java.util.concurrent.Future;
  * A future which can provide a cached result before its completion.
  * @see Future
  */
-public interface CacheableFuture<T> extends ChainableFuture<T> {
+public interface CacheableFuture<T> extends Future<T> {
 
     /**
      * @return the cached result when available

--- a/src/main/java/cz/cvut/kbss/termit/util/throttle/ChainableFuture.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/throttle/ChainableFuture.java
@@ -3,14 +3,15 @@ package cz.cvut.kbss.termit.util.throttle;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
-public interface ChainableFuture<T> extends Future<T> {
+public interface ChainableFuture<T, F extends ChainableFuture<T, F>> extends Future<T> {
 
     /**
-     * Executes this action once the future is completed normally.
-     * Action is not executed on exceptional completion.
+     * Executes this action once the future is completed.
+     * Action is executed no matter if the future is completed successfully, exceptionally or cancelled.
      * <p>
-     * If the future is already completed, action is executed synchronously.
-     * @param action action to be executed
+     * If the future is already completed, it is executed synchronously.
+     * @param action action receiving this future after completion
+     * @return this future
      */
-    ChainableFuture then(Consumer<T> action);
+    ChainableFuture<T, F> then(Consumer<F> action);
 }

--- a/src/main/java/cz/cvut/kbss/termit/util/throttle/ChainableFuture.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/throttle/ChainableFuture.java
@@ -10,6 +10,8 @@ public interface ChainableFuture<T, F extends ChainableFuture<T, F>> extends Fut
      * Action is executed no matter if the future is completed successfully, exceptionally or cancelled.
      * <p>
      * If the future is already completed, it is executed synchronously.
+     * <p>
+     * Note that you <b>must</b> use the future passed as the parameter and not the original future object.
      * @param action action receiving this future after completion
      * @return this future
      */

--- a/src/main/java/cz/cvut/kbss/termit/util/throttle/ThrottledFuture.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/throttle/ThrottledFuture.java
@@ -245,7 +245,7 @@ public class ThrottledFuture<T> implements CacheableFuture<T>, LongRunningTask {
     public ThrottledFuture<T> then(Consumer<T> action) {
         try {
             callbackLock.lock();
-            if (future.isDone() && !future.isCancelled()) {
+            if (future.isDone() && !future.isCancelled() && !future.isCompletedExceptionally()) {
                 try {
                     action.accept(future.get());
                 } catch (InterruptedException e) {
@@ -261,5 +261,13 @@ public class ThrottledFuture<T> implements CacheableFuture<T>, LongRunningTask {
             callbackLock.unlock();
         }
         return this;
+    }
+
+    /**
+     * @return {@code true} if this future completed
+     * exceptionally
+     */
+    public boolean isCompletedExceptionally() {
+        return future.isCompletedExceptionally();
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/util/throttle/ThrottledFuture.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/throttle/ThrottledFuture.java
@@ -89,11 +89,12 @@ public class ThrottledFuture<T> implements CacheableFuture<T>, ChainableFuture<T
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
+        final boolean wasCanceled = isCancelled();
         if(!future.cancel(mayInterruptIfRunning)) {
             return false;
         }
 
-        if (task != null) {
+        if (!wasCanceled && task != null) {
             callbackLock.lock();
             onCompletion.forEach(c -> c.accept(this));
             callbackLock.unlock();
@@ -268,7 +269,7 @@ public class ThrottledFuture<T> implements CacheableFuture<T>, ChainableFuture<T
 
     /**
      * @return {@code true} if this future completed
-     * exceptionally
+     * exceptionally or was cancelled.
      */
     public boolean isCompletedExceptionally() {
         return future.isCompletedExceptionally();

--- a/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottledFutureTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottledFutureTest.java
@@ -139,6 +139,18 @@ class ThrottledFutureTest {
     }
 
     @Test
+    void thenActionIsNotExecutedWhenFutureCompletedExceptionally() {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final ThrottledFuture<?> future = ThrottledFuture.of(() -> {
+            throw new RuntimeException();
+        });
+        future.run(null);
+        assertFalse(completed.get());
+        future.then(futureResult -> completed.set(true));
+        assertFalse(completed.get());
+    }
+
+    @Test
     void callingRunWillExecuteFutureOnlyOnce() {
         AtomicInteger count = new AtomicInteger(0);
         final ThrottledFuture<?> future = ThrottledFuture.of(() -> {

--- a/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottledFutureTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottledFutureTest.java
@@ -299,8 +299,8 @@ class ThrottledFutureTest {
 
     @Test
     void transferUpdatesSecondFutureWithCallbacks() {
-        final Consumer<String> firstCallback = (result) -> {};
-        final Consumer<String> secondCallback = (result) -> {};
+        final Consumer<ThrottledFuture<String>> firstCallback = (result) -> {};
+        final Consumer<ThrottledFuture<String>> secondCallback = (result) -> {};
         final ThrottledFuture<String> firstFuture = ThrottledFuture.of(()->"").then(firstCallback);
         final ThrottledFuture<String> secondFuture = ThrottledFuture.of(()->"").then(secondCallback);
         final ThrottledFuture<String> mocked = mock(ThrottledFuture.class);
@@ -323,14 +323,14 @@ class ThrottledFutureTest {
 
     @Test
     void callbacksAreClearedAfterTransferring() {
-        final Consumer<String> firstCallback = (result) -> {};
-        final Consumer<String> secondCallback = (result) -> {};
+        final Consumer<ThrottledFuture<String>> firstCallback = (result) -> {};
+        final Consumer<ThrottledFuture<String>> secondCallback = (result) -> {};
         final ThrottledFuture<String> future = ThrottledFuture.of(()->"").then(firstCallback).then(secondCallback);
         final ThrottledFuture<String> mocked = mock(ThrottledFuture.class);
 
         future.transfer(mocked);
 
-        final ArgumentCaptor<List<Consumer<String>>> captor = ArgumentCaptor.forClass(List.class);
+        final ArgumentCaptor<List<Consumer<ThrottledFuture<String>>>> captor = ArgumentCaptor.forClass(List.class);
 
         verify(mocked).update(notNull(), captor.capture());
         // captor takes the original list from the future
@@ -386,8 +386,8 @@ class ThrottledFutureTest {
 
     @Test
     void updateAddsCallbacksToTheCurrentOnes() {
-        final Consumer<String> callback = result -> {};
-        final Consumer<String> originalCallback = result -> {};
+        final Consumer<ThrottledFuture<String>> callback = result -> {};
+        final Consumer<ThrottledFuture<String>> originalCallback = result -> {};
         final ThrottledFuture<String> future = ThrottledFuture.of(() -> "").then(originalCallback);
 
         future.update(()->"", List.of(callback));

--- a/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottledFutureTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottledFutureTest.java
@@ -85,8 +85,7 @@ class ThrottledFutureTest {
 
     @Test
     void thenActionIsExecutedSynchronouslyWhenFutureIsAlreadyDoneAndNotCanceled() {
-        final Object result = new Object();
-        final ThrottledFuture<?> future = ThrottledFuture.of(() -> result);
+        final ThrottledFuture<?> future = ThrottledFuture.of(() -> null);
         final AtomicBoolean completed = new AtomicBoolean(false);
         final AtomicReference<Object> futureResult = new AtomicReference<>(null);
         future.run(null);
@@ -97,25 +96,24 @@ class ThrottledFutureTest {
             futureResult.set(fResult);
         });
         assertTrue(completed.get());
-        assertEquals(result, futureResult.get());
+        assertEquals(future, futureResult.get());
     }
 
     @Test
-    void thenActionIsNotExecutedWhenFutureIsAlreadyCancelled() {
+    void thenActionIsExecutedWhenFutureIsAlreadyCancelled() {
         final ThrottledFuture<?> future = ThrottledFuture.of(Object::new);
         final AtomicBoolean completed = new AtomicBoolean(false);
         future.cancel(false);
         assertTrue(future.isCancelled());
         future.then(result -> completed.set(true));
-        assertFalse(completed.get());
+        assertTrue(completed.get());
     }
 
     @Test
     void thenActionIsExecutedOnceFutureIsRun() {
-        final Object result = new Object();
         final AtomicBoolean completed = new AtomicBoolean(false);
         final AtomicReference<Object> fResult = new AtomicReference<>(null);
-        final ThrottledFuture<?> future = ThrottledFuture.of(() -> result);
+        final ThrottledFuture<?> future = ThrottledFuture.of(() -> null);
         future.then(futureResult -> {
             completed.set(true);
             fResult.set(futureResult);
@@ -124,22 +122,22 @@ class ThrottledFutureTest {
         assertFalse(completed.get()); // action was not executed yet
         future.run(null);
         assertTrue(completed.get());
-        assertEquals(result, fResult.get());
+        assertEquals(future, fResult.get());
     }
 
     @Test
-    void thenActionIsNotExecutedOnceFutureIsCancelled() {
+    void thenActionIsExecutedOnceFutureIsCancelled() {
         final Object result = new Object();
         final AtomicBoolean completed = new AtomicBoolean(false);
         final ThrottledFuture<?> future = ThrottledFuture.of(() -> result);
         future.then(futureResult -> completed.set(true));
         assertFalse(completed.get()); // action was not executed yet
         future.cancel(false);
-        assertFalse(completed.get());
+        assertTrue(completed.get());
     }
 
     @Test
-    void thenActionIsNotExecutedWhenFutureCompletedExceptionally() {
+    void thenActionIsExecutedWhenFutureCompletedExceptionally() {
         final AtomicBoolean completed = new AtomicBoolean(false);
         final ThrottledFuture<?> future = ThrottledFuture.of(() -> {
             throw new RuntimeException();
@@ -147,7 +145,7 @@ class ThrottledFutureTest {
         future.run(null);
         assertFalse(completed.get());
         future.then(futureResult -> completed.set(true));
-        assertFalse(completed.get());
+        assertTrue(completed.get());
     }
 
     @Test


### PR DESCRIPTION
#314 Fixes exception being thrown while adding future callback using `ThrottledFuture#then` when the future was already completed exceptionally.

Future callbacks were changed to accept the completed future instead of the result, allowing to handle the future state and result in the callback.