### PR TITLE
[Enhancement kbss-cvut/termit-ui#535] Ability to clear validation/text analysis queue

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/event/ClearLongRunningTaskQueueEvent.java
+++ b/src/main/java/cz/cvut/kbss/termit/event/ClearLongRunningTaskQueueEvent.java
@@ -1,0 +1,12 @@
+package cz.cvut.kbss.termit.event;
+
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Indicates that the long-running task queue should be cleared.
+ */
+public class ClearLongRunningTaskQueueEvent extends ApplicationEvent {
+    public ClearLongRunningTaskQueueEvent(Object source) {
+        super(source);
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/rest/AdminController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/AdminController.java
@@ -59,4 +59,15 @@ public class AdminController {
         LOG.debug("Cache invalidation request received from client.");
         adminBean.invalidateCaches();
     }
+
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
+               description = "Clears the queue of long-running tasks.")
+    @ApiResponse(responseCode = "204", description = "Long-running tasks queue cleared.")
+    @PreAuthorize("hasRole('" + SecurityConstants.ROLE_ADMIN + "')")
+    @DeleteMapping("/long-running-tasks")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void clearLongRunningTasksQueue() {
+        LOG.debug("Long-running task queue clearing request received from client.");
+        adminBean.clearLongRunningTasksQueue();
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/jmx/AppAdminBean.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/jmx/AppAdminBean.java
@@ -17,6 +17,7 @@
  */
 package cz.cvut.kbss.termit.service.jmx;
 
+import cz.cvut.kbss.termit.event.ClearLongRunningTaskQueueEvent;
 import cz.cvut.kbss.termit.event.EvictCacheEvent;
 import cz.cvut.kbss.termit.event.RefreshLastModifiedEvent;
 import cz.cvut.kbss.termit.rest.dto.HealthInfo;
@@ -65,6 +66,12 @@ public class AppAdminBean implements SelfNaming {
         eventPublisher.publishEvent(new EvictCacheEvent(this));
         LOG.info("Refreshing last modified timestamps...");
         eventPublisher.publishEvent(new RefreshLastModifiedEvent(this));
+    }
+
+    @ManagedOperation(description = "Clears the queue of long-running tasks.")
+    public void clearLongRunningTasksQueue() {
+        LOG.info("Clearing long-running tasks queue...");
+        eventPublisher.publishEvent(new ClearLongRunningTaskQueueEvent(this));
     }
 
     @ManagedOperation(description = "Sends test email to the specified address.")

--- a/src/main/java/cz/cvut/kbss/termit/util/longrunning/LongRunningTasksRegistry.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/longrunning/LongRunningTasksRegistry.java
@@ -1,16 +1,21 @@
 package cz.cvut.kbss.termit.util.longrunning;
 
+import cz.cvut.kbss.termit.event.ClearLongRunningTaskQueueEvent;
 import cz.cvut.kbss.termit.event.LongRunningTaskChangedEvent;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 public class LongRunningTasksRegistry {
@@ -38,6 +43,28 @@ public class LongRunningTasksRegistry {
         eventPublisher.publishEvent(new LongRunningTaskChangedEvent(this, status));
     }
 
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    @EventListener(ClearLongRunningTaskQueueEvent.class)
+    public void onClearLongRunningTaskQueueEvent() {
+        AtomicInteger count = new AtomicInteger();
+        LOG.info("Clearing long running task registry...");
+
+        registry.entrySet().removeIf(entry -> {
+            if (!entry.getValue().isRunning()) {
+                count.incrementAndGet();
+                return true;
+            }
+            return false;
+        });
+        performCleanup();
+
+        if (count.get() > 0) {
+            LOG.warn("Cleared {} non-running tasks from the registry", count.get());
+        } else {
+            LOG.info("Long running task registry cleared.");
+        }
+    }
+
     private void handleTaskChanged(@Nonnull final LongRunningTask task) {
         if(task.isDone()) {
             registry.remove(task.getUuid());
@@ -45,6 +72,10 @@ public class LongRunningTasksRegistry {
             registry.put(task.getUuid(), task);
         }
 
+        performCleanup();
+    }
+
+    private void performCleanup() {
         // perform cleanup
         registry.forEach((key, value) -> {
             if (value.isDone()) {


### PR DESCRIPTION
Add maintenance endpoint that allows an administrator to clear the long-running tasks queue.  
All non-running throttled futures are cancelled and non-running tasks are removed from the long-running task registry.