### PR TITLE
[Enhancement kbss-cvut/termit-ui#481] Allow disabling public view of all vocabularies/ vocabulary

### DIFF
--- a/ontology/termit-glosář.ttl
+++ b/ontology/termit-glosář.ttl
@@ -384,6 +384,17 @@ termit-pojem:omezený-uživatel-termitu
         <http://www.w3.org/2004/02/skos/core#scopeNote>
                 "He or she can list and view vocabularies and terms. He or she can also comment on terms."@en , "Může prohlížet slovníky a pojmy. Pojmy může rovněž komentovat."@cs .
 
+termit-pojem:anonymní-uživatel-termitu
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+                termit-pojem:uživatel-termitu , <https://slovník.gov.cz/základní/pojem/typ-objektu> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+                termit:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+                "Anonymous"@en , "Anonymní"@cs ;
+        <http://www.w3.org/2004/02/skos/core#scopeNote>
+        "A not logged in user"@en , "Nepřihlášený uživatel"@cs .
+
 termit-pojem:má-suffix-text-quote
         a       <http://www.w3.org/2004/02/skos/core#Concept> ;
         <http://www.w3.org/2004/02/skos/core#broader>

--- a/ontology/termit-glosář.ttl
+++ b/ontology/termit-glosář.ttl
@@ -390,8 +390,8 @@ termit-pojem:anonymní-uživatel-termitu
                 termit-pojem:uživatel-termitu , <https://slovník.gov.cz/základní/pojem/typ-objektu> ;
         <http://www.w3.org/2004/02/skos/core#inScheme>
                 termit:glosář ;
-        <http://www.w3.org/2004/02/skos/core#prefLabel>
-                "Anonymous"@en , "Anonymní"@cs ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel> 
+                "Anonymous"@en , "Anonym"@cs ;
         <http://www.w3.org/2004/02/skos/core#scopeNote>
         "A not logged in user"@en , "Nepřihlášený uživatel"@cs .
 

--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -186,6 +186,10 @@ termit-pojem:selektor-text-quote
         a                <https://slovník.gov.cz/základní/pojem/typ-objektu> , owl:Class ;
         rdfs:subClassOf  termit-pojem:selektor .
 
+termit-pojem:anonymní-uživatel-termitu
+        a                <https://slovník.gov.cz/základní/pojem/typ-objektu> , owl:Class , termit-pojem:uživatelská-role ;
+        rdfs:subClassOf  termit-pojem:uživatel-termitu .
+
 termit-pojem:omezený-uživatel-termitu
         a                <https://slovník.gov.cz/základní/pojem/typ-objektu> , owl:Class , termit-pojem:uživatelská-role ;
         rdfs:subClassOf  termit-pojem:uživatel-termitu .

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/UserRoleDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/UserRoleDao.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Repository;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class UserRoleDao {
@@ -37,8 +38,7 @@ public class UserRoleDao {
         return em.createQuery("SELECT r FROM " + UserRole.class.getSimpleName() + " r", UserRole.class).getResultList();
     }
 
-    public UserRole find(cz.cvut.kbss.termit.security.model.UserRole userRole) {
-        return em.createQuery("SELECT r FROM " + UserRole.class.getSimpleName() + " r WHERE r.uri = :uri", UserRole.class)
-                 .setParameter("uri", URI.create(userRole.getType())).getSingleResult();
+    public Optional<UserRole> find(URI id) {
+        return Optional.ofNullable(em.find(UserRole.class, id));
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/UserRoleDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/UserRoleDao.java
@@ -21,6 +21,7 @@ import cz.cvut.kbss.jopa.model.EntityManager;
 import cz.cvut.kbss.termit.model.UserRole;
 import org.springframework.stereotype.Repository;
 
+import java.net.URI;
 import java.util.List;
 
 @Repository
@@ -34,5 +35,10 @@ public class UserRoleDao {
 
     public List<UserRole> findAll() {
         return em.createQuery("SELECT r FROM " + UserRole.class.getSimpleName() + " r", UserRole.class).getResultList();
+    }
+
+    public UserRole find(cz.cvut.kbss.termit.security.model.UserRole userRole) {
+        return em.createQuery("SELECT r FROM " + UserRole.class.getSimpleName() + " r WHERE r.uri = :uri", UserRole.class)
+                 .setParameter("uri", URI.create(userRole.getType())).getSingleResult();
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/security/SecurityConstants.java
+++ b/src/main/java/cz/cvut/kbss/termit/security/SecurityConstants.java
@@ -17,6 +17,10 @@
  */
 package cz.cvut.kbss.termit.security;
 
+import cz.cvut.kbss.termit.model.acl.AccessLevel;
+
+import java.util.Set;
+
 /**
  * Security-related constants.
  */
@@ -76,6 +80,13 @@ public class SecurityConstants {
      * Restricted user role
      */
     public static final String ROLE_RESTRICTED_USER = "ROLE_RESTRICTED_USER";
+
+    /**
+     * Anonymous user role (not logged-in user)
+     */
+    public static final String ROLE_ANONYMOUS_USER = "ROLE_ANONYMOUS_USER";
+
+    public static final Set<AccessLevel> ALLOWED_ANONYMOUS_ACCESS_LEVELS = Set.of(AccessLevel.NONE, AccessLevel.READ);
 
     /**
      * Path of REST endpoints which are not secured.

--- a/src/main/java/cz/cvut/kbss/termit/security/SecurityConstants.java
+++ b/src/main/java/cz/cvut/kbss/termit/security/SecurityConstants.java
@@ -17,10 +17,6 @@
  */
 package cz.cvut.kbss.termit.security;
 
-import cz.cvut.kbss.termit.model.acl.AccessLevel;
-
-import java.util.Set;
-
 /**
  * Security-related constants.
  */
@@ -85,8 +81,6 @@ public class SecurityConstants {
      * Anonymous user role (not logged-in user)
      */
     public static final String ROLE_ANONYMOUS_USER = "ROLE_ANONYMOUS_USER";
-
-    public static final Set<AccessLevel> ALLOWED_ANONYMOUS_ACCESS_LEVELS = Set.of(AccessLevel.NONE, AccessLevel.READ);
 
     /**
      * Path of REST endpoints which are not secured.

--- a/src/main/java/cz/cvut/kbss/termit/security/model/AuthenticationToken.java
+++ b/src/main/java/cz/cvut/kbss/termit/security/model/AuthenticationToken.java
@@ -24,6 +24,9 @@ import java.security.Principal;
 import java.util.Collection;
 import java.util.Objects;
 
+/**
+ * Authentication token holding {@link TermItUserDetails} as principal.
+ */
 public class AuthenticationToken extends AbstractAuthenticationToken implements Principal {
 
     private final TermItUserDetails userDetails;

--- a/src/main/java/cz/cvut/kbss/termit/security/model/UserRole.java
+++ b/src/main/java/cz/cvut/kbss/termit/security/model/UserRole.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static cz.cvut.kbss.termit.security.SecurityConstants.ROLE_ADMIN;
+import static cz.cvut.kbss.termit.security.SecurityConstants.ROLE_ANONYMOUS_USER;
 import static cz.cvut.kbss.termit.security.SecurityConstants.ROLE_FULL_USER;
 import static cz.cvut.kbss.termit.security.SecurityConstants.ROLE_RESTRICTED_USER;
 
@@ -33,29 +34,35 @@ import static cz.cvut.kbss.termit.security.SecurityConstants.ROLE_RESTRICTED_USE
  * These roles are used for basic system authorization.
  */
 public enum UserRole {
+    /**
+     * Anonymous (not logged in) user.
+     * <p>
+     * Maps to {@link Vocabulary#s_c_anonymni_uzivatel_termitu}.
+     */
+    ANONYMOUS_USER(Vocabulary.s_c_anonymni_uzivatel_termitu, ROLE_ANONYMOUS_USER),
 
     /**
      * Restricted TermIt user.
      * <p>
      * Maps to {@link Vocabulary#s_c_omezeny_uzivatel_termitu}.
      */
-    RESTRICTED_USER(Vocabulary.s_c_omezeny_uzivatel_termitu, ROLE_RESTRICTED_USER),
+    RESTRICTED_USER(Vocabulary.s_c_omezeny_uzivatel_termitu, ROLE_RESTRICTED_USER, ANONYMOUS_USER),
 
     /**
      * Regular application user.
-     *
+     * <p>
      * Maps to {@link Vocabulary#s_c_plny_uzivatel_termitu}.
      * <p>
      * Does not map to any specific subclass of {@link Vocabulary#s_c_uzivatel_termitu}.
      */
-    FULL_USER(Vocabulary.s_c_plny_uzivatel_termitu, ROLE_FULL_USER, RESTRICTED_USER),
+    FULL_USER(Vocabulary.s_c_plny_uzivatel_termitu, ROLE_FULL_USER, RESTRICTED_USER, ANONYMOUS_USER),
 
     /**
      * Application administrator.
      * <p>
      * Maps to {@link Vocabulary#s_c_administrator_termitu}.
      */
-    ADMIN(Vocabulary.s_c_administrator_termitu, ROLE_ADMIN, FULL_USER, RESTRICTED_USER);
+    ADMIN(Vocabulary.s_c_administrator_termitu, ROLE_ADMIN, FULL_USER, RESTRICTED_USER, ANONYMOUS_USER);
 
     private final String type;
     private final String name;

--- a/src/main/java/cz/cvut/kbss/termit/service/init/SystemInitializer.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/SystemInitializer.java
@@ -44,6 +44,7 @@ public class SystemInitializer implements SmartInitializingSingleton, Ordered {
         LOG.info("Running startup tasks.");
         appContext.getBean(AdminAccountGenerator.class).initSystemAdmin();
         appContext.getBean(VocabularyAccessControlListGenerator.class).generateMissingAccessControlLists();
+        appContext.getBean(VocabularyAnonymousAccessControlListGenerator.class).generateMissingAccessControlLists();
     }
 
     @Override

--- a/src/main/java/cz/cvut/kbss/termit/service/init/VocabularyAnonymousAccessControlListGenerator.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/VocabularyAnonymousAccessControlListGenerator.java
@@ -6,7 +6,6 @@ import cz.cvut.kbss.termit.model.acl.AccessControlList;
 import cz.cvut.kbss.termit.model.acl.AccessLevel;
 import cz.cvut.kbss.termit.model.acl.RoleAccessControlRecord;
 import cz.cvut.kbss.termit.service.business.AccessControlListService;
-import cz.cvut.kbss.termit.service.repository.RepositoryAccessControlListService;
 import cz.cvut.kbss.termit.service.repository.UserRoleRepositoryService;
 import cz.cvut.kbss.termit.service.repository.VocabularyRepositoryService;
 import cz.cvut.kbss.termit.util.Vocabulary;
@@ -60,9 +59,7 @@ public class VocabularyAnonymousAccessControlListGenerator {
     @Transactional
     public void generateMissingAccessControlLists() {
         LOG.debug("Generating missing vocabulary access control records for anonymous users.");
-        final UserRole anonymousRole = userRoleRepositoryService.findAll().stream()
-                                                                .filter(RepositoryAccessControlListService::isAnonymous)
-                                                                .findAny().orElseThrow();
+        final UserRole anonymousRole = userRoleRepositoryService.find(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
         final List<URI> vocabsWithAcl = resolveVocabulariesWithAcl();
         // remove vocabularies that already have anonymous user access record
         vocabsWithAcl.removeAll(resolveVocabulariesWithAnonymousRecord());

--- a/src/main/java/cz/cvut/kbss/termit/service/init/VocabularyAnonymousAccessControlListGenerator.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/VocabularyAnonymousAccessControlListGenerator.java
@@ -1,0 +1,100 @@
+package cz.cvut.kbss.termit.service.init;
+
+import cz.cvut.kbss.jopa.model.EntityManager;
+import cz.cvut.kbss.termit.model.UserRole;
+import cz.cvut.kbss.termit.model.acl.AccessControlList;
+import cz.cvut.kbss.termit.model.acl.AccessLevel;
+import cz.cvut.kbss.termit.model.acl.RoleAccessControlRecord;
+import cz.cvut.kbss.termit.service.business.AccessControlListService;
+import cz.cvut.kbss.termit.service.repository.RepositoryAccessControlListService;
+import cz.cvut.kbss.termit.service.repository.UserRoleRepositoryService;
+import cz.cvut.kbss.termit.service.repository.VocabularyRepositoryService;
+import cz.cvut.kbss.termit.util.Configuration;
+import cz.cvut.kbss.termit.util.Vocabulary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.util.List;
+
+import static cz.cvut.kbss.termit.service.repository.RepositoryAccessControlListService.isAnonymous;
+import static cz.cvut.kbss.termit.service.repository.RepositoryAccessControlListService.isRestricted;
+
+@Service
+public class VocabularyAnonymousAccessControlListGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(VocabularyAnonymousAccessControlListGenerator.class);
+
+    private final EntityManager em;
+
+    private final VocabularyRepositoryService vocabularyService;
+
+    private final AccessControlListService aclService;
+    private final UserRoleRepositoryService userRoleRepositoryService;
+    private final Configuration.ACL aclConfig;
+
+
+    public VocabularyAnonymousAccessControlListGenerator(EntityManager em,
+                                                         VocabularyRepositoryService vocabularyService,
+                                                         AccessControlListService aclService,
+                                                         UserRoleRepositoryService userRoleRepositoryService,
+                                                         Configuration config) {
+        this.em = em;
+        this.vocabularyService = vocabularyService;
+        this.aclService = aclService;
+        this.userRoleRepositoryService = userRoleRepositoryService;
+        this.aclConfig = config.getAcl();
+    }
+
+    @Async
+    @Transactional
+    public void generateMissingAccessControlLists() {
+        LOG.debug("Generating missing vocabulary access control records for anonymous users.");
+        final UserRole anonymousRole = userRoleRepositoryService.findAll().stream()
+                                                                .filter(RepositoryAccessControlListService::isAnonymous)
+                                                                .findAny().orElseThrow();
+        final List<URI> vocabsWithoutAcl = resolveVocabulariesWithAcl();
+        LOG.trace("Generating anonymous access control records for vocabularies: {}.", vocabsWithoutAcl);
+        vocabsWithoutAcl.forEach(vUri -> {
+            final cz.cvut.kbss.termit.model.Vocabulary v = vocabularyService.findRequired(vUri);
+            aclService.findFor(v).ifPresentOrElse(acl -> {
+                if (hasAnonymous(acl)) return; // skip if already has anonymous access
+                LOG.info("Generating missing anonymous access control record for vocabulary {}.", v);
+                final AccessLevel accessLevel = shouldAllowAnonymousAccess(acl) ? AccessLevel.READ : AccessLevel.NONE;
+                aclService.addRecord(acl, new RoleAccessControlRecord(accessLevel, anonymousRole));
+            }, () -> LOG.warn("Vocabulary {} is missing an ACL.", v));
+        });
+        LOG.trace("Finished generating vocabulary access control records for anonymous users.");
+    }
+
+    private List<URI> resolveVocabulariesWithAcl() {
+        return em.createNativeQuery("""
+                         SELECT DISTINCT ?v WHERE {
+                            ?v a ?vocabulary ;
+                            ?hasAcl ?acl .
+                         }
+                         """, URI.class)
+                 .setParameter("vocabulary", URI.create(Vocabulary.s_c_slovnik))
+                 .setParameter("hasAcl", URI.create(Vocabulary.s_p_ma_seznam_rizeni_pristupu))
+                 .getResultList();
+    }
+
+    /**
+     * @return true when the ACL contains record for anonymous user role
+     */
+    private boolean hasAnonymous(AccessControlList acl) {
+        return acl.getRecords().stream().anyMatch(r -> r.getHolder() instanceof UserRole role && isAnonymous(role));
+    }
+
+    /**
+     * @return true when the ACL contains READ or greater access level for the restricted user
+     */
+    private boolean shouldAllowAnonymousAccess(AccessControlList acl) {
+        return acl.getRecords().stream().anyMatch(r ->
+                r.getHolder() instanceof UserRole role && isRestricted(role) && r.getAccessLevel()
+                                                                                 .includes(AccessLevel.READ)
+        );
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/service/init/VocabularyAnonymousAccessControlListGenerator.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/VocabularyAnonymousAccessControlListGenerator.java
@@ -59,7 +59,7 @@ public class VocabularyAnonymousAccessControlListGenerator {
     @Transactional
     public void generateMissingAccessControlLists() {
         LOG.debug("Generating missing vocabulary access control records for anonymous users.");
-        final UserRole anonymousRole = userRoleRepositoryService.find(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
+        final UserRole anonymousRole = userRoleRepositoryService.findRequired(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
         final List<URI> vocabsWithAcl = resolveVocabulariesWithAcl();
         // remove vocabularies that already have anonymous user access record
         vocabsWithAcl.removeAll(resolveVocabulariesWithAnonymousRecord());

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListService.java
@@ -187,6 +187,15 @@ public class RepositoryAccessControlListService implements AccessControlListServ
         dao.update(toUpdate);
     }
 
+    /**
+     * Ensures that the ACL contains a record for
+     * {@link cz.cvut.kbss.termit.security.model.UserRole#ANONYMOUS_USER UserRole#ANONYMOUS_USER},
+     * {@link cz.cvut.kbss.termit.security.model.UserRole#RESTRICTED_USER UserRole#RESTRICTED_USER} and
+     * {@link cz.cvut.kbss.termit.security.model.UserRole#FULL_USER UserRole#FULL_USER}
+     *
+     * @param acl the acl to verify
+     * @throws UnsupportedOperationException when some record is missing
+     */
     private void verifyUserRoleRecordsArePresent(AccessControlList acl) {
         boolean anonymousFound = false;
         boolean readerFound = false;
@@ -265,6 +274,7 @@ public class RepositoryAccessControlListService implements AccessControlListServ
      * <ul>
      *     <li>Does not grant greater access level than read to the anonymous user role</li>
      *     <li>Does not grant security access level to the restricted user role</li>
+     *     <li>Does not grant security access level to a user group</li>
      * </ul>
      *
      * @param controlRecord Access control record to validate

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListService.java
@@ -284,7 +284,7 @@ public class RepositoryAccessControlListService implements AccessControlListServ
         if (controlRecord.getHolder() instanceof UserRole role) {
             // check that the anonymous user does not have greater access level than READ
             if (isAnonymous(role) && controlRecord.getAccessLevel().compareTo(AccessLevel.READ) > 0) {
-                throw new UnsupportedOperationException("Access control record for anonymous user cannot grant greater access level then READ.");
+                throw new UnsupportedOperationException("Access control record for anonymous user cannot grant greater access level than READ.");
             }
             // check that the reader role does not have SECURITY access level
             if (isRestricted(role) && controlRecord.getAccessLevel().includes(AccessLevel.SECURITY)) {

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/UserRoleRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/UserRoleRepositoryService.java
@@ -17,11 +17,13 @@
  */
 package cz.cvut.kbss.termit.service.repository;
 
+import cz.cvut.kbss.termit.exception.NotFoundException;
 import cz.cvut.kbss.termit.model.UserRole;
 import cz.cvut.kbss.termit.persistence.dao.UserRoleDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.net.URI;
 import java.util.List;
 
 @Service
@@ -38,7 +40,8 @@ public class UserRoleRepositoryService {
         return dao.findAll();
     }
 
-    public UserRole find(cz.cvut.kbss.termit.security.model.UserRole userRole) {
-        return dao.find(userRole);
+    public UserRole findRequired(cz.cvut.kbss.termit.security.model.UserRole userRole) {
+        final URI id = URI.create(userRole.getType());
+        return dao.find(id).orElseThrow(() -> NotFoundException.create(UserRole.class, id));
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/UserRoleRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/UserRoleRepositoryService.java
@@ -37,4 +37,8 @@ public class UserRoleRepositoryService {
     public List<UserRole> findAll() {
         return dao.findAll();
     }
+
+    public UserRole find(cz.cvut.kbss.termit.security.model.UserRole userRole) {
+        return dao.find(userRole);
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/security/authorization/acl/AccessControlListBasedAuthorizationService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/security/authorization/acl/AccessControlListBasedAuthorizationService.java
@@ -64,7 +64,7 @@ public class AccessControlListBasedAuthorizationService {
      * Checks whether the specified resource can be read anonymously.
      * <p>
      * That is, if the resource is readable without a user being logged in. The implementation checks for access level
-     * of user role {@link cz.cvut.kbss.termit.security.model.UserRole#RESTRICTED_USER} - if it is {@link
+     * of user role {@link cz.cvut.kbss.termit.security.model.UserRole#ANONYMOUS_USER} - if it is {@link
      * AccessLevel#NONE}, anonymous access is denied as well. Otherwise, anonymous read access is allowed.
      *
      * @param resource Resource access to which is to be authorized
@@ -80,7 +80,7 @@ public class AccessControlListBasedAuthorizationService {
                                                                                       .filter(r -> r.getHolder()
                                                                                                     .getUri()
                                                                                                     .toString()
-                                                                                                    .equals(UserRole.RESTRICTED_USER.getType()))
+                                                                                                    .equals(UserRole.ANONYMOUS_USER.getType()))
                                                                                       .findAny());
         return record.map(r -> r.getAccessLevel().includes(AccessLevel.READ)).orElse(false);
     }

--- a/src/main/java/cz/cvut/kbss/termit/util/Configuration.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/Configuration.java
@@ -893,6 +893,11 @@ public class Configuration {
          */
         private AccessLevel defaultReaderAccessLevel = AccessLevel.READ;
 
+        /**
+         * Default access level for anonymous (non-logged-in) users.
+         */
+        private AccessLevel defaultAnonymousAccessLevel = AccessLevel.NONE;
+
         public AccessLevel getDefaultEditorAccessLevel() {
             return defaultEditorAccessLevel;
         }
@@ -907,6 +912,14 @@ public class Configuration {
 
         public void setDefaultReaderAccessLevel(AccessLevel defaultReaderAccessLevel) {
             this.defaultReaderAccessLevel = defaultReaderAccessLevel;
+        }
+
+        public AccessLevel getDefaultAnonymousAccessLevel() {
+            return defaultAnonymousAccessLevel;
+        }
+
+        public void setDefaultAnonymousAccessLevel(AccessLevel defaultAnonymousAccessLevel) {
+            this.defaultAnonymousAccessLevel = defaultAnonymousAccessLevel;
         }
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/util/Configuration.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/Configuration.java
@@ -895,6 +895,8 @@ public class Configuration {
 
         /**
          * Default access level for anonymous (non-logged-in) users.
+         * <p>
+         * Allowed values are {@link AccessLevel#NONE} and {@link AccessLevel#READ}.
          */
         private AccessLevel defaultAnonymousAccessLevel = AccessLevel.NONE;
 

--- a/src/test/java/cz/cvut/kbss/termit/environment/Generator.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/Generator.java
@@ -510,15 +510,17 @@ public class Generator {
     public static List<AccessControlRecord<?>> generateAccessControlRecords() {
         final List<AccessControlRecord<?>> result = IntStream.range(0, 5).mapToObj(i -> {
             final AccessControlRecord r;
+            int maxAccessLevel = AccessLevel.values().length; // exclusive
             if (Generator.randomBoolean()) {
                 r = new UserAccessControlRecord();
                 r.setHolder(Generator.generateUserWithId());
             } else {
                 r = new UserGroupAccessControlRecord();
                 r.setHolder(generateUserGroup());
+                maxAccessLevel = AccessLevel.SECURITY.ordinal();
             }
             r.setUri(Generator.generateUri());
-            r.setAccessLevel(AccessLevel.values()[Generator.randomIndex(AccessLevel.values())]);
+            r.setAccessLevel(AccessLevel.values()[Generator.randomInt(0, maxAccessLevel)]);
             return (AccessControlRecord<?>) r;
         }).collect(Collectors.toList());
 
@@ -533,6 +535,12 @@ public class Generator {
         rr.setHolder(restrictedRole);
         rr.setAccessLevel(AccessLevel.NONE);
         result.add(rr);
+
+        final RoleAccessControlRecord ar = new RoleAccessControlRecord();
+        final UserRole anonymousRole = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
+        ar.setHolder(anonymousRole);
+        ar.setAccessLevel(AccessLevel.NONE);
+        result.add(ar);
 
         return result;
     }

--- a/src/test/java/cz/cvut/kbss/termit/environment/Generator.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/Generator.java
@@ -521,10 +521,19 @@ public class Generator {
             r.setAccessLevel(AccessLevel.values()[Generator.randomIndex(AccessLevel.values())]);
             return (AccessControlRecord<?>) r;
         }).collect(Collectors.toList());
+
+        final RoleAccessControlRecord fr = new RoleAccessControlRecord();
+        final UserRole fullRole = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.FULL_USER);
+        fr.setHolder(fullRole);
+        fr.setAccessLevel(AccessLevel.NONE);
+        result.add(fr);
+
         final RoleAccessControlRecord rr = new RoleAccessControlRecord();
-        final UserRole role = new UserRole(URI.create(cz.cvut.kbss.termit.util.Vocabulary.s_c_plny_uzivatel_termitu));
-        rr.setHolder(role);
+        final UserRole restrictedRole = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.RESTRICTED_USER);
+        rr.setHolder(restrictedRole);
+        rr.setAccessLevel(AccessLevel.NONE);
         result.add(rr);
+
         return result;
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/security/model/TermItUserDetailsTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/security/model/TermItUserDetailsTest.java
@@ -53,7 +53,7 @@ class TermItUserDetailsTest {
         final UserAccount user = Generator.generateUserAccount();
         user.addType(Vocabulary.s_c_administrator_termitu);
         final TermItUserDetails result = new TermItUserDetails(user);
-        assertEquals(3, result.getAuthorities().size());
+        assertEquals(4, result.getAuthorities().size());
         assertTrue(result.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.RESTRICTED_USER.getName())));
         assertTrue(result.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.FULL_USER.getName())));
         assertTrue(result.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.ADMIN.getName())));
@@ -65,7 +65,7 @@ class TermItUserDetailsTest {
         final UserAccount user = Generator.generateUserAccount();
         user.addType(Vocabulary.s_c_administrator_termitu);
         final TermItUserDetails result = new TermItUserDetails(user, authorities);
-        assertEquals(4, result.getAuthorities().size());
+        assertEquals(5, result.getAuthorities().size());
         assertTrue(result.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.RESTRICTED_USER.getName())));
         assertTrue(result.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.FULL_USER.getName())));
         assertTrue(result.getAuthorities().contains(new SimpleGrantedAuthority(UserRole.ADMIN.getName())));

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListServiceTest.java
@@ -36,6 +36,8 @@ import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Vocabulary;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -44,14 +46,17 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -99,7 +104,7 @@ class RepositoryAccessControlListServiceTest {
     }
 
     private AccessControlList generateAcl() {
-        final AccessControlList acl = Generator.generateAccessControlList(false);
+        final AccessControlList acl = Generator.generateAccessControlList(true);
         when(dao.find(acl.getUri())).thenReturn(Optional.of(acl));
         return acl;
     }
@@ -131,6 +136,7 @@ class RepositoryAccessControlListServiceTest {
     @Test
     void updateRecordLoadsTargetAccessControlListAndUpdatesSpecifiedRecords() {
         final AccessControlList acl = generateAcl();
+        final int generatedRecords = acl.getRecords().size();
         final UserAccessControlRecord existingRecord = new UserAccessControlRecord();
         existingRecord.setUri(Generator.generateUri());
         existingRecord.setHolder(Generator.generateUserWithId());
@@ -143,7 +149,7 @@ class RepositoryAccessControlListServiceTest {
         update.setAccessLevel(AccessLevel.WRITE);
         sut.updateRecordAccessLevel(acl, update);
 
-        assertEquals(1, acl.getRecords().size());
+        assertEquals(generatedRecords + 1, acl.getRecords().size());
         assertEquals(update.getAccessLevel(), acl.getRecords().iterator().next().getAccessLevel());
     }
 
@@ -200,7 +206,7 @@ class RepositoryAccessControlListServiceTest {
         Environment.setCurrentUser(Generator.generateUserAccount());
         final UserRole editor = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.FULL_USER);
         final UserRole reader = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.RESTRICTED_USER);
-        when(userRoleService.findAll()).thenReturn(List.of(reader, editor));
+        when(userRoleService.findAll()).thenReturn(getAllUserRoles());
 
         final AccessControlList result = sut.createFor(subject);
         assertThat(result.getRecords(), hasItems(
@@ -236,4 +242,84 @@ class RepositoryAccessControlListServiceTest {
         verify(dao).persist(result);
         assertEquals(original.getRecords(), result.getRecords());
     }
+
+    private static List<UserRole> getAllUserRoles() {
+        return List.of(
+                new UserRole(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER),
+                new UserRole(cz.cvut.kbss.termit.security.model.UserRole.RESTRICTED_USER),
+                new UserRole(cz.cvut.kbss.termit.security.model.UserRole.FULL_USER),
+                new UserRole(cz.cvut.kbss.termit.security.model.UserRole.ADMIN)
+        );
+    }
+
+    @Test
+    void createForCreatesValidAccessControlList() {
+        final cz.cvut.kbss.termit.model.Vocabulary subject = Generator.generateVocabularyWithId();
+        final UserAccount current = Generator.generateUserAccount();
+        Environment.setCurrentUser(current);
+        when(userRoleService.findAll()).thenReturn(getAllUserRoles());
+
+        final AccessControlList result = sut.createFor(subject);
+        assertDoesNotThrow(() -> sut.validate(result));
+    }
+
+    private static Stream<AccessLevel> validateThrowsWhenRecordGrantsMoreThanRead() {
+        return Arrays.stream(AccessLevel.values()).filter(level ->
+            level.ordinal() > AccessLevel.READ.ordinal()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateThrowsWhenRecordGrantsMoreThanRead")
+    void validateThrowsWhenRecordGrantsMoreThanReadToAnonymous(AccessLevel level) {
+        final UserRole anonymous = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
+        final RoleAccessControlRecord accessRecord = new RoleAccessControlRecord();
+        accessRecord.setAccessLevel(level);
+        accessRecord.setHolder(anonymous);
+
+        when(userRoleService.findAll()).thenReturn(getAllUserRoles());
+        final AccessControlList acl = sut.createFor(Generator.generateVocabularyWithId());
+        acl.addRecord(accessRecord);
+
+        assertThrows(UnsupportedOperationException.class, () -> sut.validate(acl));
+        assertThrows(UnsupportedOperationException.class, () -> sut.validate(accessRecord));
+    }
+
+    private static Stream<AccessLevel> validateDoesNotThrowWhenRecordGrantsLessOrEqualToRead() {
+        return Arrays.stream(AccessLevel.values()).filter(level ->
+            level.ordinal() <= AccessLevel.READ.ordinal()
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validateDoesNotThrowWhenRecordGrantsLessOrEqualToRead")
+    void validateDoesNotThrowWhenRecordGrantsLessOrEqualToReadToAnonymous(AccessLevel level) {
+        final UserRole anonymous = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
+        final RoleAccessControlRecord accessRecord = new RoleAccessControlRecord();
+        accessRecord.setAccessLevel(level);
+        accessRecord.setHolder(anonymous);
+
+        when(userRoleService.findAll()).thenReturn(getAllUserRoles());
+        final AccessControlList acl = sut.createFor(Generator.generateVocabularyWithId());
+        acl.addRecord(accessRecord);
+
+        assertDoesNotThrow(() -> sut.validate(acl));
+        assertDoesNotThrow(() -> sut.validate(accessRecord));
+    }
+
+    @Test
+    void validateThrowsWhenRecordGrantsSecurityToRestricted() {
+        final UserRole restricted = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.RESTRICTED_USER);
+        final RoleAccessControlRecord accessRecord = new RoleAccessControlRecord();
+        accessRecord.setAccessLevel(AccessLevel.SECURITY);
+        accessRecord.setHolder(restricted);
+
+        when(userRoleService.findAll()).thenReturn(getAllUserRoles());
+        final AccessControlList acl = sut.createFor(Generator.generateVocabularyWithId());
+        acl.addRecord(accessRecord);
+
+        assertThrows(UnsupportedOperationException.class, () -> sut.validate(acl));
+        assertThrows(UnsupportedOperationException.class, () -> sut.validate(accessRecord));
+    }
+
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/RepositoryAccessControlListServiceTest.java
@@ -149,8 +149,12 @@ class RepositoryAccessControlListServiceTest {
         update.setAccessLevel(AccessLevel.WRITE);
         sut.updateRecordAccessLevel(acl, update);
 
+        final AccessLevel updatedLevel = acl.getRecords().stream()
+                                            .filter(r -> update.getUri().equals(r.getUri()))
+                                            .findAny().map(AccessControlRecord::getAccessLevel).orElseThrow();
+
         assertEquals(generatedRecords + 1, acl.getRecords().size());
-        assertEquals(update.getAccessLevel(), acl.getRecords().iterator().next().getAccessLevel());
+        assertEquals(update.getAccessLevel(), updatedLevel);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/security/authorization/acl/AccessControlListBasedAuthorizationServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/security/authorization/acl/AccessControlListBasedAuthorizationServiceTest.java
@@ -299,24 +299,23 @@ class AccessControlListBasedAuthorizationServiceTest {
 
     @ParameterizedTest
     @MethodSource("canReadAnonymouslyTestArguments")
-    void canReadAnonymouslyReturnsCorrectResultForUserSpecifiedReaderRoleAccessLevel(Boolean expected, AccessLevel accessLevel) {
+    void canReadAnonymouslyReturnsCorrectResultForAnonymousUserRoleAccessLevel(Boolean canRead, AccessLevel accessLevel) {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         final AccessControlList acl = Generator.generateAccessControlList(false);
-        final UserRole role = new UserRole(URI.create(cz.cvut.kbss.termit.security.model.UserRole.RESTRICTED_USER.getType()));
+        final UserRole role = new UserRole(cz.cvut.kbss.termit.security.model.UserRole.ANONYMOUS_USER);
         final RoleAccessControlRecord roleRecord = new RoleAccessControlRecord(accessLevel, role);
         roleRecord.setUri(Generator.generateUri());
         acl.addRecord(roleRecord);
         when(aclService.findFor(vocabulary)).thenReturn(Optional.of(acl));
 
-        assertEquals(expected, sut.canReadAnonymously(vocabulary));
+        assertEquals(canRead, sut.canReadAnonymously(vocabulary));
     }
 
     static Stream<Arguments> canReadAnonymouslyTestArguments() {
         return Stream.of(
                 Arguments.of(false, AccessLevel.NONE),
-                Arguments.of(true, AccessLevel.READ),
-                Arguments.of(true, AccessLevel.WRITE)
-                // Reader cannot have Security access
+                Arguments.of(true, AccessLevel.READ)
+                // WRITE and SECURITY access levels are not allowed for anonymous users
         );
     }
 }


### PR DESCRIPTION
Introduces a new user role - anonymous user, representing a not-logged-in user.

Access Control Lists / Records are now being validated, enforcing the presence of records for anonymous, restricted, and full user roles.
Validation also ensures that an access control record:
- Does not grant greater access level than read to the anonymous user role
- Does not grant security access level to the restricted user role
- Does not grant security access level to a user group

Until now, these rules were only controlled by FE.

Init service `VocabularyAnonymousAccessControlListGenerator` was introduced for *data migration* to generate missing access control records for anonymous user role.

Resolves kbss-cvut/termit-ui#481