### PR TITLE
[Bug #304] Fix Validation throttling leaving some tasks hanging

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/util/longrunning/LongRunningTaskStatus.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/longrunning/LongRunningTaskStatus.java
@@ -27,11 +27,22 @@ public class LongRunningTaskStatus implements Serializable {
         this.uuid = task.getUuid();
     }
 
+    public LongRunningTaskStatus(@Nonnull String name, @Nonnull UUID uuid, @Nonnull State state,
+                                 @Nullable Instant startedAt) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(uuid);
+        Objects.requireNonNull(state);
+        this.name = name;
+        this.uuid = uuid;
+        this.state = state;
+        this.startedAt = startedAt;
+    }
+
     public @Nonnull String getName() {
         return name;
     }
 
-    public State getState() {
+    public @Nonnull State getState() {
         return state;
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/util/longrunning/LongRunningTasksRegistry.java
+++ b/src/main/java/cz/cvut/kbss/termit/util/longrunning/LongRunningTasksRegistry.java
@@ -52,6 +52,12 @@ public class LongRunningTasksRegistry {
         registry.entrySet().removeIf(entry -> {
             if (!entry.getValue().isRunning()) {
                 count.incrementAndGet();
+                if (entry.getValue().getName() != null) {
+                    // announce that the task is done
+                    final LongRunningTaskStatus doneStatus = new LongRunningTaskStatus(entry.getValue().getName(),
+                            entry.getKey(), LongRunningTaskStatus.State.DONE, null);
+                    eventPublisher.publishEvent(new LongRunningTaskChangedEvent(this, doneStatus));
+                }
                 return true;
             }
             return false;


### PR DESCRIPTION
resolves #304 

# The issue
The issue was caused in [ThrottleAspect#getFutureTask](https://github.com/kbss-cvut/termit/blob/d61d5e3981d3fda6a1f3af4acc6d90e3fb3c340c/src/main/java/cz/cvut/kbss/termit/util/throttle/ThrottleAspect.java#L383) which in a specific case directly returns future returned from throttled method dropping the original throttled future passed in method parameter.
The future from the throttled method is returned by `ThrottleAspect#getFutureTask` when it is already resolved.
This happens for example in [ResultCachingValidator#validate](https://github.com/kbss-cvut/termit/blob/d61d5e3981d3fda6a1f3af4acc6d90e3fb3c340c/src/main/java/cz/cvut/kbss/termit/persistence/validation/ResultCachingValidator.java#L86) when the cached result is available, and no heavy computation is required.
The original throttled future from the method parameter can be either a new "empty" throttled future or an already scheduled one from the previous throttled call awaiting execution.
The original schedule was canceled (inside `doThrottle`) because of the new throttled call, which is expected to be "merged."
However, when the throttled method returned an already resolved future, it was returned by `getFutureTask`, and the old throttled future was dropped, so its state in the long-running task registry was never updated.
Additionally, on completion callbacks from the old future were never resolved.

The existing methods for update/transfer cannot be used to fix the issue as they do not allow merge/transfer from/to futures that are already running or done.
For this case, `ThrottledFuture#consumeCallbacks` was introduced. 
When the old throttled future is not running and not resolved, it will remove all callbacks from it and resolve them in a new on-completion callback added to the current future (using the `then` method), and the old future is canceled (which will update the long-running-task registry).
Using `then` method allows automatic execution of these callbacks when the current future has already been resolved (which is our case).
This way, old callbacks can be resolved using this new future and the old future appears to be cancelled in the registry.

___

# Refactoring

- `LongRunningTaskRegistry` will construct an artificial task state `DONE` and dispatch it as a state update when the administrator clears the long-running task queue. This allows to update FE with WebSocket without the need to refresh the page.
- lock handling in `ThrottledFuture` was refactored to use `tryLock` with timeouts (500ms) instead of manual spin wait with thread yield (which is now handled internally and more efficiently).