### PR TITLE
[Ref #318] Remove dependency on AspectJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
-            <artifactId>spring-aspects</artifactId>
+            <artifactId>spring-aop</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.retry</groupId>
@@ -173,10 +173,6 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <version>5.2.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.aspectj</groupId>
-            <artifactId>aspectjrt</artifactId>
         </dependency>
 
         <!-- JWT support for Java -->
@@ -438,39 +434,6 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>dev.aspectj</groupId>
-                <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.13.1</version>
-                <configuration>
-                    <complianceLevel>${java.version}</complianceLevel>
-                    <aspectLibraries>
-                        <aspectLibrary>
-                            <groupId>org.springframework</groupId>
-                            <artifactId>spring-aspects</artifactId>
-                        </aspectLibrary>
-                    </aspectLibraries>
-                    <parameters>true</parameters>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>main</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <!-- Weave all main classes -->
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test</id>
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <!-- Weave all test classes -->
-                            <goal>test-compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/src/main/java/cz/cvut/kbss/termit/config/AppConfig.java
+++ b/src/main/java/cz/cvut/kbss/termit/config/AppConfig.java
@@ -24,7 +24,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.context.annotation.ImportResource;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -34,7 +33,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 @Configuration
 @EnableMBeanExport
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-@EnableSpringConfigured
 @EnableAsync
 @EnableScheduling
 @EnableRetry

--- a/src/main/java/cz/cvut/kbss/termit/model/AbstractTerm.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/AbstractTerm.java
@@ -101,6 +101,18 @@ public abstract class AbstractTerm extends Asset<MultilingualString>
         return label;
     }
 
+    public String getLabel(String language) {
+        return this.getLabel() != null ? this.getLabel().get(language) : null;
+    }
+
+    public void setLabel(String language, String label) {
+        if (this.getLabel() == null) {
+            this.setLabel(MultilingualString.create(label, language));
+        } else {
+            this.getLabel().set(language, label);
+        }
+    }
+
     @Override
     public void setLabel(MultilingualString label) {
         this.label = label;

--- a/src/main/java/cz/cvut/kbss/termit/model/Term.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/Term.java
@@ -36,10 +36,7 @@ import cz.cvut.kbss.termit.model.assignment.TermDefinitionSource;
 import cz.cvut.kbss.termit.model.changetracking.Audited;
 import cz.cvut.kbss.termit.model.util.HasTypes;
 import cz.cvut.kbss.termit.model.util.SupportsSnapshots;
-import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Vocabulary;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Configurable;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -48,16 +45,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-@Configurable
 @Audited
 @OWLClass(iri = SKOS.CONCEPT)
 @JsonLdAttributeOrder({"uri", "label", "description", "subTerms"})
 @JsonIgnoreProperties({"persistenceContext"})
 public class Term extends AbstractTerm implements HasTypes, SupportsSnapshots {
-
-    @Autowired
-    @Transient
-    private transient Configuration config;
 
     @OWLAnnotationProperty(iri = SKOS.ALT_LABEL)
     private Set<MultilingualString> altLabels;
@@ -130,37 +122,6 @@ public class Term extends AbstractTerm implements HasTypes, SupportsSnapshots {
 
     public Term(URI uri) {
         setUri(uri);
-    }
-
-    /**
-     * Sets label in the application-configured language.
-     * <p>
-     * This is a convenience method allowing to skip working with {@link MultilingualString} instances.
-     *
-     * @param label Label value to set
-     * @see #setLabel(MultilingualString)
-     */
-    @JsonIgnore
-    public void setPrimaryLabel(String label) {
-        if (this.getLabel() == null) {
-            this.setLabel(MultilingualString.create(label, config.getPersistence().getLanguage()));
-        } else {
-            this.getLabel().set(config.getPersistence().getLanguage(), label);
-        }
-    }
-
-    /**
-     * Gets label in the application-configured language.
-     * <p>
-     * This is a convenience method allowing to skip working with {@link MultilingualString} instances.
-     *
-     * @return Label value
-     * @see #getLabel()
-     */
-    @JsonIgnore
-    @Override
-    public String getPrimaryLabel() {
-        return getLabel() != null ? getLabel().get(config.getPersistence().getLanguage()) : null;
     }
 
     public Set<MultilingualString> getAltLabels() {

--- a/src/main/java/cz/cvut/kbss/termit/model/Vocabulary.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/Vocabulary.java
@@ -27,7 +27,6 @@ import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
 import cz.cvut.kbss.jopa.model.annotations.Properties;
-import cz.cvut.kbss.jopa.model.annotations.Transient;
 import cz.cvut.kbss.jopa.model.annotations.Types;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
@@ -36,11 +35,8 @@ import cz.cvut.kbss.termit.model.resource.Document;
 import cz.cvut.kbss.termit.model.util.AssetVisitor;
 import cz.cvut.kbss.termit.model.util.HasTypes;
 import cz.cvut.kbss.termit.model.util.SupportsSnapshots;
-import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.validation.PrimaryNotBlank;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Configurable;
 
 import java.io.Serializable;
 import java.net.URI;
@@ -49,15 +45,10 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Configurable
 @Audited
 @OWLClass(iri = cz.cvut.kbss.termit.util.Vocabulary.s_c_slovnik)
 @JsonLdAttributeOrder({"uri", "label", "description"})
 public class Vocabulary extends Asset<MultilingualString> implements HasTypes, SupportsSnapshots, Serializable {
-
-    @Autowired
-    @Transient
-    private transient Configuration config;
 
     @PrimaryNotBlank
     @ParticipationConstraints(nonEmpty = true)
@@ -112,35 +103,16 @@ public class Vocabulary extends Asset<MultilingualString> implements HasTypes, S
         this.label = label;
     }
 
-    /**
-     * Sets label in the application-configured language.
-     * <p>
-     * This is a convenience method allowing to skip working with {@link MultilingualString} instances.
-     *
-     * @param label Label value to set
-     * @see #setLabel(MultilingualString)
-     */
-    @JsonIgnore
-    public void setPrimaryLabel(String label) {
-        if (this.getLabel() == null) {
-            this.setLabel(MultilingualString.create(label, config.getPersistence().getLanguage()));
-        } else {
-            this.getLabel().set(config.getPersistence().getLanguage(), label);
-        }
+    public String getLabel(String language) {
+        return this.getLabel() != null ? this.getLabel().get(language) : null;
     }
 
-    /**
-     * Gets label in the application-configured language.
-     * <p>
-     * This is a convenience method allowing to skip working with {@link MultilingualString} instances.
-     *
-     * @return Label value
-     * @see #getLabel()
-     */
-    @JsonIgnore
-    @Override
-    public String getPrimaryLabel() {
-        return getLabel() != null ? getLabel().get(config.getPersistence().getLanguage()) : null;
+    public void setLabel(String language, String label) {
+        if (this.getLabel() == null) {
+            this.setLabel(MultilingualString.create(label, language));
+        } else {
+            this.getLabel().set(language, label);
+        }
     }
 
     public MultilingualString getDescription() {

--- a/src/main/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactory.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactory.java
@@ -24,6 +24,7 @@ import cz.cvut.kbss.termit.model.resource.Resource;
 import cz.cvut.kbss.termit.model.util.AssetVisitor;
 import cz.cvut.kbss.termit.service.mail.ApplicationLinkBuilder;
 import cz.cvut.kbss.termit.service.repository.DataRepositoryService;
+import cz.cvut.kbss.termit.util.Configuration;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
@@ -35,34 +36,41 @@ public class MessageAssetFactory {
 
     private final ApplicationLinkBuilder linkBuilder;
 
-    public MessageAssetFactory(DataRepositoryService dataService, ApplicationLinkBuilder linkBuilder) {
+    private final Configuration config;
+
+    public MessageAssetFactory(DataRepositoryService dataService, ApplicationLinkBuilder linkBuilder,
+                               Configuration config) {
         this.dataService = dataService;
         this.linkBuilder = linkBuilder;
+        this.config = config;
     }
 
     public MessageAsset create(Asset<?> asset) {
-        final MessageLabelExtractor labelExtractor = new MessageLabelExtractor(dataService);
+        final MessageLabelExtractor labelExtractor = new MessageLabelExtractor(config, dataService);
         asset.accept(labelExtractor);
         return new MessageAsset(labelExtractor.label, linkBuilder.linkTo(asset));
     }
 
     private static class MessageLabelExtractor implements AssetVisitor {
+        private final Configuration config;
         private final DataRepositoryService dataService;
 
         String label;
 
-        private MessageLabelExtractor(DataRepositoryService dataService) {
+        private MessageLabelExtractor(Configuration config, DataRepositoryService dataService) {
+            this.config = config;
             this.dataService = dataService;
         }
 
         @Override
         public void visitTerm(AbstractTerm term) {
-            this.label = term.getPrimaryLabel() + " (" + dataService.getLabel(term.getVocabulary(), null).orElse("") + ")";
+            this.label = term.getLabel(config.getPersistence().getLanguage()) +
+                    " (" + dataService.getLabel(term.getVocabulary(), null).orElse("") + ")";
         }
 
         @Override
         public void visitVocabulary(Vocabulary vocabulary) {
-            this.label = vocabulary.getPrimaryLabel();
+            this.label = vocabulary.getLabel(config.getPersistence().getLanguage());
         }
 
         @Override

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -104,6 +104,10 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
         return vocabularyDao;
     }
 
+    private String getPrimaryLabel(Vocabulary vocabulary) {
+        return vocabulary.getLabel(config.getPersistence().getLanguage());
+    }
+
     // Cache only if all vocabularies are editable
     @Cacheable(condition = "@'termit-cz.cvut.kbss.termit.util.Configuration'.workspace.allVocabulariesEditable")
     @Override
@@ -137,7 +141,7 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
         super.prePersist(instance);
         if (instance.getUri() == null) {
             instance.setUri(
-                    idResolver.generateIdentifier(config.getNamespace().getVocabulary(), instance.getPrimaryLabel()));
+                    idResolver.generateIdentifier(config.getNamespace().getVocabulary(), getPrimaryLabel(instance)));
         }
         verifyIdentifierUnique(instance);
         initGlossaryAndModel(instance);
@@ -168,7 +172,7 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
                                                  Constants.DEFAULT_DOCUMENT_IRI_COMPONENT));
         doc.setLabel(
                 new MessageFormatter(config.getPersistence().getLanguage()).formatMessage("vocabulary.document.label",
-                                                                                          vocabulary.getPrimaryLabel()));
+                        getPrimaryLabel(vocabulary)));
         vocabulary.setDocument(doc);
     }
 
@@ -333,7 +337,7 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
         if (!vocabularies.isEmpty()) {
             throw new AssetRemovalException(
                     "Vocabulary cannot be removed. It is referenced from other vocabularies: "
-                            + vocabularies.stream().map(Vocabulary::getPrimaryLabel).collect(Collectors.joining(", ")));
+                            + vocabularies.stream().map(this::getPrimaryLabel).collect(Collectors.joining(", ")));
         }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
-application.version: @project.version@
+application.version: '@project.version@'
 
 management:
     endpoints:
@@ -38,7 +38,7 @@ spring:
                     starttls:
                         enable: true
     profiles:
-        active: @spring.profiles.active@
+        active: '@spring.profiles.active@'
 javamelody:
     init-parameters:
         authorized-users: admin:kral0vnat3rm1t1st3

--- a/src/test/java/cz/cvut/kbss/termit/environment/Environment.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/Environment.java
@@ -220,4 +220,36 @@ public class Environment {
             conn.commit();
         }
     }
+
+    /**
+     * @return label in {@link #LANGUAGE}
+     */
+    public static String getPrimaryLabel(Term term) {
+        return term.getLabel(Environment.LANGUAGE);
+    }
+
+    /**
+     * @return label in {@link #LANGUAGE}
+     */
+    public static String getPrimaryLabel(cz.cvut.kbss.termit.model.Vocabulary vocabulary) {
+        return vocabulary.getLabel(Environment.LANGUAGE);
+    }
+
+    /**
+     * Sets label in {@link #LANGUAGE}
+     *
+     * @param label label to set
+     */
+    public static void setPrimaryLabel(Term term, String label) {
+        term.setLabel(Environment.LANGUAGE, label);
+    }
+
+    /**
+     * Sets label in {@link #LANGUAGE}
+     *
+     * @param label label to set
+     */
+    public static void setPrimaryLabel(cz.cvut.kbss.termit.model.Vocabulary vocabulary, String label) {
+        vocabulary.setLabel(Environment.LANGUAGE, label);
+    }
 }

--- a/src/test/java/cz/cvut/kbss/termit/environment/Environment.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/Environment.java
@@ -49,7 +49,6 @@ import org.springframework.security.core.context.SecurityContextImpl;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
@@ -203,25 +202,6 @@ public class Environment {
 
     public static List<TermDto> termsToDtos(List<Term> terms) {
         return terms.stream().map(TermDto::new).collect(Collectors.toList());
-    }
-
-    /**
-     * Injects the specified {@link Configuration} object into the specified
-     * {@link cz.cvut.kbss.termit.model.Vocabulary} instance.
-     * <p>
-     * This simulates Spring {@code @Configurable} behavior.
-     *
-     * @param vocabulary Target instance
-     * @param config     Instance to inject
-     */
-    public static void injectConfiguration(cz.cvut.kbss.termit.model.Vocabulary vocabulary, Configuration config) {
-        try {
-            final Field configField = cz.cvut.kbss.termit.model.Vocabulary.class.getDeclaredField("config");
-            configField.setAccessible(true);
-            configField.set(vocabulary, config);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Unable to inject configuration into Vocabulary instance.", e);
-        }
     }
 
     /**

--- a/src/test/java/cz/cvut/kbss/termit/environment/config/TestConfig.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/config/TestConfig.java
@@ -20,9 +20,7 @@ package cz.cvut.kbss.termit.environment.config;
 import cz.cvut.kbss.termit.util.Configuration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 
-@EnableSpringConfigured
 @EnableConfigurationProperties({Configuration.class})
 public class TestConfig {
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseAssetDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseAssetDaoTest.java
@@ -2,7 +2,6 @@ package cz.cvut.kbss.termit.persistence.dao;
 
 import cz.cvut.kbss.jopa.model.EntityManager;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
-import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.event.AssetPersistEvent;
 import cz.cvut.kbss.termit.event.AssetUpdateEvent;
@@ -19,6 +18,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import java.net.URI;
 import java.util.Optional;
 
+import static cz.cvut.kbss.termit.environment.Environment.setPrimaryLabel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.atLeastOnce;
@@ -64,7 +64,7 @@ class BaseAssetDaoTest extends BaseDaoTestRunner{
     void updatePublishesAssetUpdateEvent() {
         final Term t = Generator.generateTermWithId();
         transactional(() -> em.persist(t));
-        t.setLabel(Environment.LANGUAGE, "Updated primary label");
+        setPrimaryLabel(t, "Updated primary label");
 
         transactional(() -> sut.update(t));
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseAssetDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseAssetDaoTest.java
@@ -2,6 +2,7 @@ package cz.cvut.kbss.termit.persistence.dao;
 
 import cz.cvut.kbss.jopa.model.EntityManager;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.event.AssetPersistEvent;
 import cz.cvut.kbss.termit.event.AssetUpdateEvent;
@@ -63,7 +64,7 @@ class BaseAssetDaoTest extends BaseDaoTestRunner{
     void updatePublishesAssetUpdateEvent() {
         final Term t = Generator.generateTermWithId();
         transactional(() -> em.persist(t));
-        t.setPrimaryLabel("Updated primary label");
+        t.setLabel(Environment.LANGUAGE, "Updated primary label");
 
         transactional(() -> sut.update(t));
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseDaoTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseDaoTestRunner.java
@@ -36,4 +36,5 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @ActiveProfiles("test")
 public abstract class BaseDaoTestRunner extends TransactionalTestRunner {
+
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseDaoTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/BaseDaoTestRunner.java
@@ -23,7 +23,6 @@ import cz.cvut.kbss.termit.util.Configuration;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -32,7 +31,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(Configuration.class)
-@EnableSpringConfigured
 @ContextConfiguration(classes = {TestPersistenceConfig.class},
                       initializers = {ConfigDataApplicationContextInitializer.class})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/DataDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/DataDaoTest.java
@@ -133,7 +133,7 @@ class DataDaoTest extends BaseDaoTestRunner {
 
         final Optional<String> result = sut.getLabel(term.getUri());
         assertTrue(result.isPresent());
-        assertEquals(term.getPrimaryLabel(), result.get());
+        assertEquals(term.getLabel(Environment.LANGUAGE), result.get());
     }
 
     @Test
@@ -146,14 +146,14 @@ class DataDaoTest extends BaseDaoTestRunner {
             try (final RepositoryConnection connection = repo.getConnection()) {
                 connection.add(vf.createIRI(term.getUri().toString()), RDF.TYPE, SKOS.CONCEPT);
                 connection.add(vf.createIRI(term.getUri().toString()), SKOS.PREF_LABEL,
-                               vf.createLiteral(term.getPrimaryLabel()));
+                        vf.createLiteral(term.getLabel(Environment.LANGUAGE)));
                 connection.commit();
             }
         });
 
         final Optional<String> result = sut.getLabel(term.getUri());
         assertTrue(result.isPresent());
-        assertEquals(term.getPrimaryLabel(), result.get());
+        assertEquals(term.getLabel(Environment.LANGUAGE), result.get());
     }
 
     @Test
@@ -177,7 +177,7 @@ class DataDaoTest extends BaseDaoTestRunner {
             try (final RepositoryConnection connection = repo.getConnection()) {
                 connection.add(vf.createIRI(term.getUri().toString()), RDF.TYPE, SKOS.CONCEPT);
                 connection.add(vf.createIRI(term.getUri().toString()), SKOS.PREF_LABEL,
-                               vf.createLiteral(term.getPrimaryLabel()));
+                        vf.createLiteral(term.getLabel(Environment.LANGUAGE)));
                 connection.add(vf.createIRI(term.getUri().toString()), SKOS.PREF_LABEL,
                                vf.createLiteral("Another label"));
                 connection.commit();

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/DataDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/DataDaoTest.java
@@ -53,6 +53,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -133,7 +134,7 @@ class DataDaoTest extends BaseDaoTestRunner {
 
         final Optional<String> result = sut.getLabel(term.getUri());
         assertTrue(result.isPresent());
-        assertEquals(term.getLabel(Environment.LANGUAGE), result.get());
+        assertEquals(getPrimaryLabel(term), result.get());
     }
 
     @Test
@@ -146,14 +147,14 @@ class DataDaoTest extends BaseDaoTestRunner {
             try (final RepositoryConnection connection = repo.getConnection()) {
                 connection.add(vf.createIRI(term.getUri().toString()), RDF.TYPE, SKOS.CONCEPT);
                 connection.add(vf.createIRI(term.getUri().toString()), SKOS.PREF_LABEL,
-                        vf.createLiteral(term.getLabel(Environment.LANGUAGE)));
+                        vf.createLiteral(getPrimaryLabel(term)));
                 connection.commit();
             }
         });
 
         final Optional<String> result = sut.getLabel(term.getUri());
         assertTrue(result.isPresent());
-        assertEquals(term.getLabel(Environment.LANGUAGE), result.get());
+        assertEquals(getPrimaryLabel(term), result.get());
     }
 
     @Test
@@ -177,7 +178,7 @@ class DataDaoTest extends BaseDaoTestRunner {
             try (final RepositoryConnection connection = repo.getConnection()) {
                 connection.add(vf.createIRI(term.getUri().toString()), RDF.TYPE, SKOS.CONCEPT);
                 connection.add(vf.createIRI(term.getUri().toString()), SKOS.PREF_LABEL,
-                        vf.createLiteral(term.getLabel(Environment.LANGUAGE)));
+                        vf.createLiteral(getPrimaryLabel(term)));
                 connection.add(vf.createIRI(term.getUri().toString()), SKOS.PREF_LABEL,
                                vf.createLiteral("Another label"));
                 connection.commit();

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
@@ -110,7 +110,8 @@ class SearchDaoTest extends BaseDaoTestRunner {
 
     @Test
     void defaultFullTextSearchFindsTermsWithMatchingLabel() {
-        final Collection<Term> matching = terms.stream().filter(t -> t.getPrimaryLabel().contains("Matching"))
+        final Collection<Term> matching = terms.stream()
+                                               .filter(t -> t.getLabel(Environment.LANGUAGE).contains("Matching"))
                                                .collect(Collectors.toList());
 
         final List<FullTextSearchResult> allResults = sut.fullTextSearch("matching");
@@ -126,7 +127,7 @@ class SearchDaoTest extends BaseDaoTestRunner {
             final boolean b = Generator.randomBoolean();
             final Term term = new Term();
             term.setUri(Generator.generateUri());
-            term.setPrimaryLabel(b ? "Matching label " + i : "Unknown label " + i);
+            term.setLabel(Environment.LANGUAGE, b ? "Matching label " + i : "Unknown label " + i);
             vocabulary.getGlossary().addRootTerm(term);
             term.setVocabulary(vocabulary.getUri());
             if (b) {
@@ -139,14 +140,15 @@ class SearchDaoTest extends BaseDaoTestRunner {
                                                               Environment.LANGUAGE)));
             terms.add(term);
         }
-        terms.sort(Comparator.comparing(Term::getPrimaryLabel));
+        terms.sort(Comparator.comparing(t -> t.getLabel(Environment.LANGUAGE)));
         return terms;
     }
 
     @Test
     void defaultFullTextSearchFindsVocabulariesWithMatchingLabel() {
         final Collection<Vocabulary> matching = vocabularies.stream()
-                                                            .filter(v -> v.getPrimaryLabel().contains("Matching"))
+                                                            .filter(v -> v.getLabel(Environment.LANGUAGE)
+                                                                          .contains("Matching"))
                                                             .collect(Collectors.toList());
         final List<FullTextSearchResult> allResults = sut.fullTextSearch("matching");
         final List<FullTextSearchResult> vocabularyResults = allResults.stream()
@@ -163,7 +165,7 @@ class SearchDaoTest extends BaseDaoTestRunner {
         vocabularies.forEach(v -> {
             v.setUri(Generator.generateUri());
             if (Generator.randomBoolean()) {
-                v.setPrimaryLabel("Matching label " + Generator.randomInt());
+                v.setLabel(Environment.LANGUAGE, "Matching label " + Generator.randomInt());
             }
         });
         return vocabularies;
@@ -171,10 +173,11 @@ class SearchDaoTest extends BaseDaoTestRunner {
 
     @Test
     void defaultFullTextSearchFindsVocabulariesAndTermsWithMatchingLabel() {
-        final Collection<Term> matchingTerms = terms.stream().filter(t -> t.getPrimaryLabel().contains("Matching"))
+        final Collection<Term> matchingTerms = terms.stream()
+                                                    .filter(t -> t.getLabel(Environment.LANGUAGE).contains("Matching"))
                                                     .toList();
         final Collection<Vocabulary> matchingVocabularies = vocabularies.stream()
-                                                                        .filter(v -> v.getPrimaryLabel()
+                                                                        .filter(v -> v.getLabel(Environment.LANGUAGE)
                                                                                       .contains("Matching"))
                                                                         .toList();
         final List<FullTextSearchResult> result = sut.fullTextSearch("matching");
@@ -190,7 +193,8 @@ class SearchDaoTest extends BaseDaoTestRunner {
 
     @Test
     void defaultFullTextSearchIncludesTermStateInResult() {
-        final Collection<Term> matching = terms.stream().filter(t -> t.getPrimaryLabel().contains("Matching"))
+        final Collection<Term> matching = terms.stream()
+                                               .filter(t -> t.getLabel(Environment.LANGUAGE).contains("Matching"))
                                                .toList();
 
         final List<FullTextSearchResult> allResults = sut.fullTextSearch("matching");
@@ -215,9 +219,9 @@ class SearchDaoTest extends BaseDaoTestRunner {
     void defaultFullTextSearchSkipsSnapshots() {
         final String matchingLabel = "Snapshot";
         final Vocabulary v = Generator.generateVocabularyWithId();
-        v.setPrimaryLabel(matchingLabel + " 0");
+        v.setLabel(Environment.LANGUAGE, matchingLabel + " 0");
         final Vocabulary snapshot = Generator.generateVocabularyWithId();
-        snapshot.setPrimaryLabel(matchingLabel + " 1");
+        snapshot.setLabel(Environment.LANGUAGE, matchingLabel + " 1");
         transactional(() -> {
             em.persist(v);
             em.persist(snapshot);

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
@@ -53,6 +53,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
+import static cz.cvut.kbss.termit.environment.Environment.setPrimaryLabel;
 import static cz.cvut.kbss.termit.environment.util.ContainsSameEntities.containsSameEntities;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -111,7 +113,7 @@ class SearchDaoTest extends BaseDaoTestRunner {
     @Test
     void defaultFullTextSearchFindsTermsWithMatchingLabel() {
         final Collection<Term> matching = terms.stream()
-                                               .filter(t -> t.getLabel(Environment.LANGUAGE).contains("Matching"))
+                                               .filter(t -> getPrimaryLabel(t).contains("Matching"))
                                                .collect(Collectors.toList());
 
         final List<FullTextSearchResult> allResults = sut.fullTextSearch("matching");
@@ -127,7 +129,7 @@ class SearchDaoTest extends BaseDaoTestRunner {
             final boolean b = Generator.randomBoolean();
             final Term term = new Term();
             term.setUri(Generator.generateUri());
-            term.setLabel(Environment.LANGUAGE, b ? "Matching label " + i : "Unknown label " + i);
+            setPrimaryLabel(term, b ? "Matching label " + i : "Unknown label " + i);
             vocabulary.getGlossary().addRootTerm(term);
             term.setVocabulary(vocabulary.getUri());
             if (b) {
@@ -140,15 +142,14 @@ class SearchDaoTest extends BaseDaoTestRunner {
                                                               Environment.LANGUAGE)));
             terms.add(term);
         }
-        terms.sort(Comparator.comparing(t -> t.getLabel(Environment.LANGUAGE)));
+        terms.sort(Comparator.comparing(Environment::getPrimaryLabel));
         return terms;
     }
 
     @Test
     void defaultFullTextSearchFindsVocabulariesWithMatchingLabel() {
         final Collection<Vocabulary> matching = vocabularies.stream()
-                                                            .filter(v -> v.getLabel(Environment.LANGUAGE)
-                                                                          .contains("Matching"))
+                                                            .filter(v -> getPrimaryLabel(v).contains("Matching"))
                                                             .collect(Collectors.toList());
         final List<FullTextSearchResult> allResults = sut.fullTextSearch("matching");
         final List<FullTextSearchResult> vocabularyResults = allResults.stream()
@@ -165,7 +166,7 @@ class SearchDaoTest extends BaseDaoTestRunner {
         vocabularies.forEach(v -> {
             v.setUri(Generator.generateUri());
             if (Generator.randomBoolean()) {
-                v.setLabel(Environment.LANGUAGE, "Matching label " + Generator.randomInt());
+                setPrimaryLabel(v, "Matching label " + Generator.randomInt());
             }
         });
         return vocabularies;
@@ -174,10 +175,10 @@ class SearchDaoTest extends BaseDaoTestRunner {
     @Test
     void defaultFullTextSearchFindsVocabulariesAndTermsWithMatchingLabel() {
         final Collection<Term> matchingTerms = terms.stream()
-                                                    .filter(t -> t.getLabel(Environment.LANGUAGE).contains("Matching"))
+                                                    .filter(t -> getPrimaryLabel(t).contains("Matching"))
                                                     .toList();
         final Collection<Vocabulary> matchingVocabularies = vocabularies.stream()
-                                                                        .filter(v -> v.getLabel(Environment.LANGUAGE)
+                                                                        .filter(v -> getPrimaryLabel(v)
                                                                                       .contains("Matching"))
                                                                         .toList();
         final List<FullTextSearchResult> result = sut.fullTextSearch("matching");
@@ -194,7 +195,7 @@ class SearchDaoTest extends BaseDaoTestRunner {
     @Test
     void defaultFullTextSearchIncludesTermStateInResult() {
         final Collection<Term> matching = terms.stream()
-                                               .filter(t -> t.getLabel(Environment.LANGUAGE).contains("Matching"))
+                                               .filter(t -> getPrimaryLabel(t).contains("Matching"))
                                                .toList();
 
         final List<FullTextSearchResult> allResults = sut.fullTextSearch("matching");
@@ -219,9 +220,9 @@ class SearchDaoTest extends BaseDaoTestRunner {
     void defaultFullTextSearchSkipsSnapshots() {
         final String matchingLabel = "Snapshot";
         final Vocabulary v = Generator.generateVocabularyWithId();
-        v.setLabel(Environment.LANGUAGE, matchingLabel + " 0");
+        setPrimaryLabel(v, matchingLabel + " 0");
         final Vocabulary snapshot = Generator.generateVocabularyWithId();
-        snapshot.setLabel(Environment.LANGUAGE, matchingLabel + " 1");
+        setPrimaryLabel(snapshot, matchingLabel + " 1");
         transactional(() -> {
             em.persist(v);
             em.persist(snapshot);

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoSnapshotsTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoSnapshotsTest.java
@@ -22,7 +22,6 @@ import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
-import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
@@ -47,6 +46,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
 import static cz.cvut.kbss.termit.environment.util.ContainsSameEntities.containsSameEntities;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
@@ -213,7 +213,7 @@ public class TermDaoSnapshotsTest extends BaseTermDaoTestRunner {
         enableRdfsInference(em);
         final Term term = generateTermWithSnapshot();
 
-        final List<TermDto> result = sut.findAll(term.getLabel(Environment.LANGUAGE));
+        final List<TermDto> result = sut.findAll(getPrimaryLabel(term));
         assertEquals(Collections.singletonList(new TermDto(term)), result);
     }
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoSnapshotsTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoSnapshotsTest.java
@@ -22,6 +22,7 @@ import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
+import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
@@ -212,7 +213,7 @@ public class TermDaoSnapshotsTest extends BaseTermDaoTestRunner {
         enableRdfsInference(em);
         final Term term = generateTermWithSnapshot();
 
-        final List<TermDto> result = sut.findAll(term.getPrimaryLabel());
+        final List<TermDto> result = sut.findAll(term.getLabel(Environment.LANGUAGE));
         assertEquals(Collections.singletonList(new TermDto(term)), result);
     }
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermOccurrenceDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermOccurrenceDaoTest.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static cz.cvut.kbss.termit.environment.Environment.setPrimaryLabel;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.emptyCollectionOf;
@@ -112,10 +113,10 @@ class TermOccurrenceDaoTest extends BaseDaoTestRunner {
         }
         final Term tOne = new Term();
         tOne.setUri(Generator.generateUri());
-        tOne.setLabel(Environment.LANGUAGE, "Term one");
+        setPrimaryLabel(tOne, "Term one");
         final Term tTwo = new Term();
         tTwo.setUri(Generator.generateUri());
-        tTwo.setLabel(Environment.LANGUAGE, "Term two");
+        setPrimaryLabel(tTwo, "Term two");
         final Map<Term, List<TermOccurrence>> map = new HashMap<>();
         map.put(tOne, new ArrayList<>());
         map.put(tTwo, new ArrayList<>());

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermOccurrenceDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermOccurrenceDaoTest.java
@@ -112,10 +112,10 @@ class TermOccurrenceDaoTest extends BaseDaoTestRunner {
         }
         final Term tOne = new Term();
         tOne.setUri(Generator.generateUri());
-        tOne.setPrimaryLabel("Term one");
+        tOne.setLabel(Environment.LANGUAGE, "Term one");
         final Term tTwo = new Term();
         tTwo.setUri(Generator.generateUri());
-        tTwo.setPrimaryLabel("Term two");
+        tTwo.setLabel(Environment.LANGUAGE, "Term two");
         final Map<Term, List<TermOccurrence>> map = new HashMap<>();
         map.put(tOne, new ArrayList<>());
         map.put(tTwo, new ArrayList<>());

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -135,7 +135,7 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
         transactional(() -> vocabularies.forEach(v -> em.persist(v, descriptorFor(v))));
 
         final List<Vocabulary> result = sut.findAll();
-        vocabularies.sort(Comparator.comparing(Vocabulary::getPrimaryLabel));
+        vocabularies.sort(Comparator.comparing(v -> v.getLabel(Environment.LANGUAGE)));
         for (int i = 0; i < vocabularies.size(); i++) {
             assertEquals(vocabularies.get(i).getUri(), result.get(i).getUri());
         }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDaoTest.java
@@ -135,7 +135,7 @@ class VocabularyDaoTest extends BaseDaoTestRunner {
         transactional(() -> vocabularies.forEach(v -> em.persist(v, descriptorFor(v))));
 
         final List<Vocabulary> result = sut.findAll();
-        vocabularies.sort(Comparator.comparing(v -> v.getLabel(Environment.LANGUAGE)));
+        vocabularies.sort(Comparator.comparing(Environment::getPrimaryLabel));
         for (int i = 0; i < vocabularies.size(); i++) {
             assertEquals(vocabularies.get(i).getUri(), result.get(i).getUri());
         }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/skos/SKOSImporterTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/skos/SKOSImporterTest.java
@@ -61,6 +61,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
 import static cz.cvut.kbss.termit.environment.Generator.generateVocabulary;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -314,7 +315,7 @@ class SKOSImporterTest extends BaseDaoTestRunner {
                                                        Environment.loadFile("data/test-glossary.ttl")));
             assertNotNull(result);
             assertEquals(VOCABULARY_IRI, result.getUri());
-            assertEquals("Vocabulary of system TermIt - glossary", result.getLabel(Environment.LANGUAGE));
+            assertEquals("Vocabulary of system TermIt - glossary", getPrimaryLabel(result));
         });
     }
 

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/skos/SKOSImporterTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/skos/SKOSImporterTest.java
@@ -314,7 +314,7 @@ class SKOSImporterTest extends BaseDaoTestRunner {
                                                        Environment.loadFile("data/test-glossary.ttl")));
             assertNotNull(result);
             assertEquals(VOCABULARY_IRI, result.getUri());
-            assertEquals("Vocabulary of system TermIt - glossary", result.getPrimaryLabel());
+            assertEquals("Vocabulary of system TermIt - glossary", result.getLabel(Environment.LANGUAGE));
         });
     }
 

--- a/src/test/java/cz/cvut/kbss/termit/rest/AdminBasedRegistrationControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/AdminBasedRegistrationControllerTest.java
@@ -38,8 +38,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -57,10 +55,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AdminBasedRegistrationController.class)
-@EnableAspectJAutoProxy(proxyTargetClass = true)
 @EnableTransactionManagement
 @ExtendWith(SpringExtension.class)
-@EnableSpringConfigured
 @EnableConfigurationProperties({Configuration.class})
 @ContextConfiguration(classes = {
         TestRestSecurityConfig.class,

--- a/src/test/java/cz/cvut/kbss/termit/rest/AdminBasedRegistrationControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/AdminBasedRegistrationControllerTest.java
@@ -38,6 +38,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -55,6 +56,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(AdminBasedRegistrationController.class)
+@EnableAspectJAutoProxy
 @EnableTransactionManagement
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties({Configuration.class})

--- a/src/test/java/cz/cvut/kbss/termit/service/BaseServiceTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/BaseServiceTestRunner.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -36,10 +34,8 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import java.net.URI;
 
-@EnableAspectJAutoProxy(proxyTargetClass = true)
 @EnableTransactionManagement
 @ExtendWith(SpringExtension.class)
-@EnableSpringConfigured
 @EnableConfigurationProperties({Configuration.class})
 @ContextConfiguration(classes = {
         TestPersistenceConfig.class,

--- a/src/test/java/cz/cvut/kbss/termit/service/BaseServiceTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/BaseServiceTestRunner.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 import java.net.URI;
 
+@EnableAspectJAutoProxy
 @EnableTransactionManagement
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties({Configuration.class})

--- a/src/test/java/cz/cvut/kbss/termit/service/changetracking/ChangeTrackingTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/changetracking/ChangeTrackingTest.java
@@ -116,7 +116,7 @@ public class ChangeTrackingTest extends BaseServiceTestRunner {
     void updatingVocabularyLiteralAttributeCreatesUpdateChangeRecord() {
         enableRdfsInference(em);
         transactional(() -> em.persist(vocabulary, descriptorFactory.vocabularyDescriptor(vocabulary)));
-        vocabulary.setPrimaryLabel("Updated vocabulary label");
+        vocabulary.setLabel(Environment.LANGUAGE, "Updated vocabulary label");
         transactional(() -> vocabularyService.update(vocabulary));
 
         final List<AbstractChangeRecord> result = changeRecordDao.findAll(vocabulary);
@@ -134,7 +134,7 @@ public class ChangeTrackingTest extends BaseServiceTestRunner {
             em.persist(imported, descriptorFactory.vocabularyDescriptor(imported));
             em.persist(vocabulary, descriptorFactory.vocabularyDescriptor(vocabulary));
         });
-        vocabulary.setPrimaryLabel("Updated vocabulary label");
+        vocabulary.setLabel(Environment.LANGUAGE, "Updated vocabulary label");
         vocabulary.setImportedVocabularies(Collections.singleton(imported.getUri()));
         transactional(() -> vocabularyService.update(vocabulary));
 

--- a/src/test/java/cz/cvut/kbss/termit/service/changetracking/ChangeTrackingTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/changetracking/ChangeTrackingTest.java
@@ -45,6 +45,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 
+import static cz.cvut.kbss.termit.environment.Environment.setPrimaryLabel;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.empty;
@@ -116,7 +117,7 @@ public class ChangeTrackingTest extends BaseServiceTestRunner {
     void updatingVocabularyLiteralAttributeCreatesUpdateChangeRecord() {
         enableRdfsInference(em);
         transactional(() -> em.persist(vocabulary, descriptorFactory.vocabularyDescriptor(vocabulary)));
-        vocabulary.setLabel(Environment.LANGUAGE, "Updated vocabulary label");
+        setPrimaryLabel(vocabulary, "Updated vocabulary label");
         transactional(() -> vocabularyService.update(vocabulary));
 
         final List<AbstractChangeRecord> result = changeRecordDao.findAll(vocabulary);
@@ -134,7 +135,7 @@ public class ChangeTrackingTest extends BaseServiceTestRunner {
             em.persist(imported, descriptorFactory.vocabularyDescriptor(imported));
             em.persist(vocabulary, descriptorFactory.vocabularyDescriptor(vocabulary));
         });
-        vocabulary.setLabel(Environment.LANGUAGE, "Updated vocabulary label");
+        setPrimaryLabel(vocabulary, "Updated vocabulary label");
         vocabulary.setImportedVocabularies(Collections.singleton(imported.getUri()));
         transactional(() -> vocabularyService.update(vocabulary));
 

--- a/src/test/java/cz/cvut/kbss/termit/service/export/SKOSVocabularyExporterTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/export/SKOSVocabularyExporterTest.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -120,7 +121,7 @@ class SKOSVocabularyExporterTest extends BaseServiceTestRunner {
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), RDF.TYPE, SKOS.CONCEPT_SCHEME)));
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), RDF.TYPE, OWL.ONTOLOGY)));
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), DCTERMS.TITLE,
-                vf.createLiteral(vocabulary.getLabel(Environment.LANGUAGE), lang()))));
+                vf.createLiteral(getPrimaryLabel(vocabulary), lang()))));
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), DCTERMS.DESCRIPTION,
                                                      vf.createLiteral(vocabulary.getDescription().get(lang()), lang()))));
     }

--- a/src/test/java/cz/cvut/kbss/termit/service/export/SKOSVocabularyExporterTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/export/SKOSVocabularyExporterTest.java
@@ -120,7 +120,7 @@ class SKOSVocabularyExporterTest extends BaseServiceTestRunner {
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), RDF.TYPE, SKOS.CONCEPT_SCHEME)));
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), RDF.TYPE, OWL.ONTOLOGY)));
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), DCTERMS.TITLE,
-                                                     vf.createLiteral(vocabulary.getPrimaryLabel(), lang()))));
+                vf.createLiteral(vocabulary.getLabel(Environment.LANGUAGE), lang()))));
         assertThat(model, hasItem(vf.createStatement(glossaryIri(vocabulary), DCTERMS.DESCRIPTION,
                                                      vf.createLiteral(vocabulary.getDescription().get(lang()), lang()))));
     }

--- a/src/test/java/cz/cvut/kbss/termit/service/notification/CommentChangeNotifierTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/notification/CommentChangeNotifierTest.java
@@ -17,7 +17,6 @@
  */
 package cz.cvut.kbss.termit.service.notification;
 
-import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.Term;
@@ -52,6 +51,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
 import static cz.cvut.kbss.termit.environment.util.ContainsSameEntities.containsSameEntities;
 import static cz.cvut.kbss.termit.service.notification.CommentChangeNotifier.COMMENT_CHANGES_TEMPLATE;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -179,7 +179,7 @@ class CommentChangeNotifierTest {
                 Collections.singletonList(comment));
         final String link = "http://localhost/termit";
         when(messageAssetFactory.create(term)).thenReturn(
-                new MessageAssetFactory.MessageAsset(term.getLabel(Environment.LANGUAGE), link));
+                new MessageAssetFactory.MessageAsset(getPrimaryLabel(term), link));
         when(messageComposer.composeMessage(any(), anyMap())).thenReturn("Test message content");
 
         final Optional<Message> result = sut.createCommentChangesMessage(from, to);
@@ -193,7 +193,7 @@ class CommentChangeNotifierTest {
         assertEquals(LocalDate.ofInstant(from, ZoneId.systemDefault()), variables.get("from"));
         assertEquals(LocalDate.ofInstant(to, ZoneId.systemDefault()), variables.get("to"));
         assertEquals(Collections.singletonList(new CommentChangeNotifier.AssetWithComments(
-                        new MessageAssetFactory.MessageAsset(term.getLabel(Environment.LANGUAGE), link),
+                        new MessageAssetFactory.MessageAsset(getPrimaryLabel(term), link),
                              Collections.singletonList(new CommentChangeNotifier.CommentForMessage(comment)))),
                      variables.get("commentedAssets"));
     }

--- a/src/test/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactoryTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactoryTest.java
@@ -23,15 +23,12 @@ import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.service.mail.ApplicationLinkBuilder;
 import cz.cvut.kbss.termit.service.repository.DataRepositoryService;
-import cz.cvut.kbss.termit.util.Configuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.lang.reflect.Field;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,16 +43,12 @@ class MessageAssetFactoryTest {
     @Mock
     private DataRepositoryService dataService;
 
-    @Spy
-    private Configuration config = new Configuration();
-
     @InjectMocks
     private MessageAssetFactory sut;
 
     @Test
     void createUsesVocabularyTitleAndLinkBuilderGeneratedLinkToConstructMessageAsset() {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
-        Environment.injectConfiguration(vocabulary, config);
         when(linkBuilder.linkTo(vocabulary)).thenReturn(vocabulary.getUri().toString());
 
         final MessageAssetFactory.MessageAsset result = sut.create(vocabulary);
@@ -64,18 +57,14 @@ class MessageAssetFactoryTest {
     }
 
     @Test
-    void createAddsTermVocabularyLabelInParenthesesAsMessageAssetLabel() throws Exception {
+    void createAddsTermVocabularyLabelInParenthesesAsMessageAssetLabel() {
         final String vocabularyLabel = "Vocabulary " + Generator.randomInt(0, 1000);
         final Term term = Generator.generateTermWithId();
         when(linkBuilder.linkTo(term)).thenReturn(term.getUri().toString());
         when(dataService.getLabel(term.getVocabulary(), null)).thenReturn(Optional.of(vocabularyLabel));
-        // Simulate autowired configuration
-        final Field configField = Term.class.getDeclaredField("config");
-        configField.setAccessible(true);
-        configField.set(term, new Configuration());
 
         final MessageAssetFactory.MessageAsset result = sut.create(term);
-        assertEquals(term.getPrimaryLabel() + " (" + vocabularyLabel + ")", result.getLabel());
+        assertEquals(term.getLabel(Environment.LANGUAGE) + " (" + vocabularyLabel + ")", result.getLabel());
         assertEquals(term.getUri().toString(), result.getLink());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactoryTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactoryTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -72,7 +73,7 @@ class MessageAssetFactoryTest {
         when(dataService.getLabel(term.getVocabulary(), null)).thenReturn(Optional.of(vocabularyLabel));
 
         final MessageAssetFactory.MessageAsset result = sut.create(term);
-        assertEquals(term.getLabel(Environment.LANGUAGE) + " (" + vocabularyLabel + ")", result.getLabel());
+        assertEquals(getPrimaryLabel(term) + " (" + vocabularyLabel + ")", result.getLabel());
         assertEquals(term.getUri().toString(), result.getLink());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactoryTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/notification/MessageAssetFactoryTest.java
@@ -23,10 +23,12 @@ import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.service.mail.ApplicationLinkBuilder;
 import cz.cvut.kbss.termit.service.repository.DataRepositoryService;
+import cz.cvut.kbss.termit.util.Configuration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -42,6 +44,12 @@ class MessageAssetFactoryTest {
 
     @Mock
     private DataRepositoryService dataService;
+
+    /**
+     * Used for injection in {@link #sut}
+     */
+    @Spy
+    private Configuration configuration = new Configuration();
 
     @InjectMocks
     private MessageAssetFactory sut;

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryServiceTest.java
@@ -57,6 +57,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
+import static cz.cvut.kbss.termit.environment.Environment.getPrimaryLabel;
+import static cz.cvut.kbss.termit.environment.Environment.setPrimaryLabel;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
@@ -112,7 +114,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     @Test
     void persistThrowsValidationExceptionWhenVocabularyNameIsBlank() {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
-        vocabulary.setLabel(Environment.LANGUAGE, "");
+        setPrimaryLabel(vocabulary, "");
         final ValidationException exception = assertThrows(ValidationException.class, () -> sut.persist(vocabulary));
         assertThat(exception.getMessage(),
                    containsString("label in the primary configured language must not be blank"));
@@ -146,7 +148,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     void persistCreatesGlossaryAndModelInstances() {
         final Vocabulary vocabulary = new Vocabulary();
         vocabulary.setUri(Generator.generateUri());
-        vocabulary.setLabel(Environment.LANGUAGE, "TestVocabulary");
+        setPrimaryLabel(vocabulary, "TestVocabulary");
         sut.persist(vocabulary);
         final Vocabulary result = em.find(Vocabulary.class, vocabulary.getUri());
         assertNotNull(result.getGlossary());
@@ -168,7 +170,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         transactional(() -> em.persist(vocabulary, descriptorFor(vocabulary)));
 
-        vocabulary.setLabel(Environment.LANGUAGE, "");
+        setPrimaryLabel(vocabulary, "");
         assertThrows(ValidationException.class, () -> sut.update(vocabulary));
     }
 
@@ -312,10 +314,6 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         assertThat(result, lessThanOrEqualTo(System.currentTimeMillis()));
     }
 
-    String getPrimaryLabel(Vocabulary vocabulary) {
-        return vocabulary.getLabel(Environment.LANGUAGE);
-    }
-
     @Test
     void importVocabularyImportsAValidVocabulary() {
         final String skos =
@@ -391,7 +389,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     void persistGeneratesGlossaryIriBasedOnVocabularyIriAndConfiguredFragment() {
         final String label = "Test vocabulary " + System.currentTimeMillis();
         final Vocabulary vocabulary = new Vocabulary();
-        vocabulary.setLabel(Environment.LANGUAGE, label);
+        setPrimaryLabel(vocabulary, label);
         sut.persist(vocabulary);
         assertNotNull(vocabulary.getUri());
         assertNotNull(vocabulary.getGlossary());
@@ -405,7 +403,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     void persistGeneratesModelIriBasedOnVocabularyIri() {
         final String label = "Test vocabulary " + System.currentTimeMillis();
         final Vocabulary vocabulary = new Vocabulary();
-        vocabulary.setLabel(Environment.LANGUAGE, label);
+        setPrimaryLabel(vocabulary, label);
         sut.persist(vocabulary);
         assertNotNull(vocabulary.getUri());
         assertNotNull(vocabulary.getModel());
@@ -430,7 +428,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         vocabulary.addType(cz.cvut.kbss.termit.util.Vocabulary.s_c_verze_slovniku);
         transactional(() -> em.persist(vocabulary, descriptorFor(vocabulary)));
 
-        vocabulary.setLabel(Environment.LANGUAGE, "Updated label");
+        setPrimaryLabel(vocabulary, "Updated label");
         assertThrows(SnapshotNotEditableException.class, () -> sut.update(vocabulary));
     }
 
@@ -443,7 +441,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         final Vocabulary update = new Vocabulary(vocabulary.getUri());
         update.setModel(vocabulary.getModel());
         update.setGlossary(vocabulary.getGlossary());
-        update.setLabel(Environment.LANGUAGE, "Updated label");
+        setPrimaryLabel(update, "Updated label");
         // Intentionally leave ACL null, this is how it would arrive from the client
 
         transactional(() -> sut.update(update));

--- a/src/test/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryServiceTest.java
@@ -112,7 +112,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     @Test
     void persistThrowsValidationExceptionWhenVocabularyNameIsBlank() {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
-        vocabulary.setPrimaryLabel("");
+        vocabulary.setLabel(Environment.LANGUAGE, "");
         final ValidationException exception = assertThrows(ValidationException.class, () -> sut.persist(vocabulary));
         assertThat(exception.getMessage(),
                    containsString("label in the primary configured language must not be blank"));
@@ -127,7 +127,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         final Vocabulary result = em.find(Vocabulary.class, vocabulary.getUri());
         assertNotNull(result);
         assertThat(result.getUri().toString(),
-                   containsString(IdentifierResolver.normalize(vocabulary.getPrimaryLabel())));
+                containsString(IdentifierResolver.normalize(getPrimaryLabel(vocabulary))));
     }
 
     @Test
@@ -146,7 +146,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     void persistCreatesGlossaryAndModelInstances() {
         final Vocabulary vocabulary = new Vocabulary();
         vocabulary.setUri(Generator.generateUri());
-        vocabulary.setPrimaryLabel("TestVocabulary");
+        vocabulary.setLabel(Environment.LANGUAGE, "TestVocabulary");
         sut.persist(vocabulary);
         final Vocabulary result = em.find(Vocabulary.class, vocabulary.getUri());
         assertNotNull(result.getGlossary());
@@ -168,7 +168,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         transactional(() -> em.persist(vocabulary, descriptorFor(vocabulary)));
 
-        vocabulary.setPrimaryLabel("");
+        vocabulary.setLabel(Environment.LANGUAGE, "");
         assertThrows(ValidationException.class, () -> sut.update(vocabulary));
     }
 
@@ -312,6 +312,10 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         assertThat(result, lessThanOrEqualTo(System.currentTimeMillis()));
     }
 
+    String getPrimaryLabel(Vocabulary vocabulary) {
+        return vocabulary.getLabel(Environment.LANGUAGE);
+    }
+
     @Test
     void importVocabularyImportsAValidVocabulary() {
         final String skos =
@@ -329,7 +333,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         );
 
         final Vocabulary v = sut.importVocabulary(true, mf);
-        assertEquals(v.getPrimaryLabel(), "Test");
+        assertEquals("Test", getPrimaryLabel(v));
     }
 
     @Test
@@ -349,7 +353,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         );
 
         final Vocabulary v = sut.importVocabulary(true, mf);
-        assertEquals(v.getPrimaryLabel(), "Test");
+        assertEquals("Test", getPrimaryLabel(v));
     }
 
     @Test
@@ -367,7 +371,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
                     skos.getBytes(StandardCharsets.UTF_8)
             );
             final Vocabulary v = sut.importVocabulary(false, mf);
-            assertEquals(v.getPrimaryLabel(), "Test");
+            assertEquals("Test", getPrimaryLabel(v));
         });
     }
 
@@ -387,7 +391,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     void persistGeneratesGlossaryIriBasedOnVocabularyIriAndConfiguredFragment() {
         final String label = "Test vocabulary " + System.currentTimeMillis();
         final Vocabulary vocabulary = new Vocabulary();
-        vocabulary.setPrimaryLabel(label);
+        vocabulary.setLabel(Environment.LANGUAGE, label);
         sut.persist(vocabulary);
         assertNotNull(vocabulary.getUri());
         assertNotNull(vocabulary.getGlossary());
@@ -401,7 +405,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
     void persistGeneratesModelIriBasedOnVocabularyIri() {
         final String label = "Test vocabulary " + System.currentTimeMillis();
         final Vocabulary vocabulary = new Vocabulary();
-        vocabulary.setPrimaryLabel(label);
+        vocabulary.setLabel(Environment.LANGUAGE, label);
         sut.persist(vocabulary);
         assertNotNull(vocabulary.getUri());
         assertNotNull(vocabulary.getModel());
@@ -426,7 +430,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         vocabulary.addType(cz.cvut.kbss.termit.util.Vocabulary.s_c_verze_slovniku);
         transactional(() -> em.persist(vocabulary, descriptorFor(vocabulary)));
 
-        vocabulary.setPrimaryLabel("Updated label");
+        vocabulary.setLabel(Environment.LANGUAGE, "Updated label");
         assertThrows(SnapshotNotEditableException.class, () -> sut.update(vocabulary));
     }
 
@@ -439,7 +443,7 @@ class VocabularyRepositoryServiceTest extends BaseServiceTestRunner {
         final Vocabulary update = new Vocabulary(vocabulary.getUri());
         update.setModel(vocabulary.getModel());
         update.setGlossary(vocabulary.getGlossary());
-        update.setPrimaryLabel("Updated label");
+        update.setLabel(Environment.LANGUAGE, "Updated label");
         // Intentionally leave ACL null, this is how it would arrive from the client
 
         transactional(() -> sut.update(update));

--- a/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottleAspectTestContextConfig.java
+++ b/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottleAspectTestContextConfig.java
@@ -5,12 +5,14 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.mockito.Answers.RETURNS_SMART_NULLS;
 
 @TestConfiguration
+@EnableAspectJAutoProxy
 @ImportResource("classpath*:spring-aop.xml")
 @ComponentScan(value = "cz.cvut.kbss.termit.util.throttle")
 public class ThrottleAspectTestContextConfig {

--- a/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottleAspectTestContextConfig.java
+++ b/src/test/java/cz/cvut/kbss/termit/util/throttle/ThrottleAspectTestContextConfig.java
@@ -5,17 +5,13 @@ import org.mockito.Mockito;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.ImportResource;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.mockito.Answers.RETURNS_SMART_NULLS;
 
 @TestConfiguration
-@EnableSpringConfigured
 @ImportResource("classpath*:spring-aop.xml")
-@EnableAspectJAutoProxy(proxyTargetClass = true)
 @ComponentScan(value = "cz.cvut.kbss.termit.util.throttle")
 public class ThrottleAspectTestContextConfig {
 

--- a/src/test/java/cz/cvut/kbss/termit/websocket/BaseWebSocketIntegrationTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/websocket/BaseWebSocketIntegrationTestRunner.java
@@ -31,6 +31,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
@@ -55,7 +56,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 @EnableAutoConfiguration
 @EnableTransactionManagement
 @ExtendWith(MockitoExtension.class)
-//@EnableAspectJAutoProxy(proxyTargetClass = true) // aspectJ autoproxy
+@EnableAspectJAutoProxy
 @EnableConfigurationProperties({Configuration.class})
 @ContextConfiguration(
         classes = {TestConfig.class, TestPersistenceConfig.class, TestServiceConfig.class, AppConfig.class,

--- a/src/test/java/cz/cvut/kbss/termit/websocket/BaseWebSocketIntegrationTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/websocket/BaseWebSocketIntegrationTestRunner.java
@@ -31,8 +31,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.EnableAspectJAutoProxy;
-import org.springframework.context.annotation.aspectj.EnableSpringConfigured;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
@@ -54,11 +52,10 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ActiveProfiles("test")
-@EnableSpringConfigured
 @EnableAutoConfiguration
 @EnableTransactionManagement
 @ExtendWith(MockitoExtension.class)
-@EnableAspectJAutoProxy(proxyTargetClass = true)
+//@EnableAspectJAutoProxy(proxyTargetClass = true) // aspectJ autoproxy
 @EnableConfigurationProperties({Configuration.class})
 @ContextConfiguration(
         classes = {TestConfig.class, TestPersistenceConfig.class, TestServiceConfig.class, AppConfig.class,


### PR DESCRIPTION
resolves #318 

Removed:
- aspectjrt
- spring-aspects
- aspectj-maven-plugin

Added:
- spring-aop (for ThrottleAspect)

Maven placeholders in `application.properties` were added into quotes, which allows us to build and run the application in IDE without processing resources with Maven.

Removed `@Configured` from entities (Term, Vocabulary) for autowiring configuration.

Accessors for `PrimaryLabel` were refactored to  
`String getLabel(String language)` and `void setLabel(String language, String label)`