### PR TITLE
[Perf #327] Improve performance of analysis of all vocabulary terms

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -329,6 +329,8 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
     /**
      * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy.
      * Filters terms that have label and definition in the instance language.
+     * <p>
+     * Terms are loaded <b>without</b> their subterms.
      *
      * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
      * @return List of vocabulary term DTOs ordered by label

--- a/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/VocabularyController.java
@@ -405,7 +405,7 @@ public class VocabularyController extends BaseController {
                                                      example = ApiDoc.ID_NAMESPACE_EXAMPLE)
                                           @RequestParam(name = QueryParams.NAMESPACE,
                                                         required = false) Optional<String> namespace) {
-        vocabularyService.runTextAnalysisOnAllTerms(getById(localName, namespace));
+        vocabularyService.runTextAnalysisOnAllTerms(resolveVocabularyUri(localName, namespace));
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -142,6 +142,8 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
     /**
      * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy.
      * Filters terms that have label and definition in the instance language.
+     * <p>
+     * Terms are loaded <b>without</b> their subterms.
      *
      * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
      * @return List of vocabulary term DTOs ordered by label

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -378,7 +378,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         Objects.requireNonNull(owner);
         languageService.getInitialTermState().ifPresent(is -> term.setState(is.getUri()));
         repositoryService.addRootTermToVocabulary(term, owner);
-        vocabularyService.runTextAnalysisOnAllTerms(owner);
+        vocabularyService.runTextAnalysisOnAllTerms(owner.getUri());
     }
 
     /**
@@ -393,7 +393,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         Objects.requireNonNull(parent);
         languageService.getInitialTermState().ifPresent(is -> child.setState(is.getUri()));
         repositoryService.addChildTerm(child, parent);
-        vocabularyService.runTextAnalysisOnAllTerms(findVocabularyRequired(parent.getVocabulary()));
+        vocabularyService.runTextAnalysisOnAllTerms(parent.getVocabulary());
     }
 
     /**
@@ -412,7 +412,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         final Term result = repositoryService.update(term);
         // if the label changed, run analysis on all terms in the vocabulary
         if (!Objects.equals(original.getLabel(), result.getLabel())) {
-            vocabularyService.runTextAnalysisOnAllTerms(getVocabularyReference(result.getVocabulary()));
+            vocabularyService.runTextAnalysisOnAllTerms(result.getVocabulary());
             // if all terms have not been analyzed, check if the definition has changed,
             // and if so, perform an analysis for the term definition
         } else if (!Objects.equals(original.getDefinition(), result.getDefinition())) {

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -61,6 +61,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -453,6 +454,10 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         }
         LOG.debug("Analyzing definition of term {}.", term);
         textAnalysisService.analyzeTermDefinition(term, vocabularyContextMapper.getVocabularyContext(vocabularyIri));
+    }
+
+    public void analyzeTermDefinitions(Map<URI, List<AbstractTerm>> contextToTerms) {
+        textAnalysisService.analyzeTermDefinitions(contextToTerms);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -456,6 +456,14 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         textAnalysisService.analyzeTermDefinition(term, vocabularyContextMapper.getVocabularyContext(vocabularyIri));
     }
 
+    /**
+     * Analyzes term definitions for the given context-to-terms map.
+     * <p>
+     * Text analysis is invoked on all definitions merged for better efficiency.
+     *
+     * @param contextToTerms Map of vocabulary context URIs to lists of terms.
+     * @see TextAnalysisService#analyzeTermDefinitions(Map)
+     */
     public void analyzeTermDefinitions(Map<URI, List<AbstractTerm>> contextToTerms) {
         textAnalysisService.analyzeTermDefinitions(contextToTerms);
     }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -140,6 +140,18 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
     }
 
     /**
+     * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy.
+     * Filters terms that have label and definition in the instance language.
+     *
+     * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
+     * @return List of vocabulary term DTOs ordered by label
+     */
+    public List<TermDto> findAllWithDefinition(Vocabulary vocabulary) {
+        Objects.requireNonNull(vocabulary);
+        return repositoryService.findAllWithDefinition(vocabulary);
+    }
+
+    /**
      * Gets the total number of terms in the specified vocabulary.
      *
      * @param vocabulary Vocabulary reference

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -366,10 +366,10 @@ public class VocabularyService
         final Vocabulary vocabulary = findRequired(vocabularyUri); // required when throttling for persistent context
         LOG.debug("Analyzing definitions of all terms in vocabulary {} and vocabularies it imports.", vocabulary);
         SnapshotProvider.verifySnapshotNotModified(vocabulary);
-        final List<TermDto> allTerms = termService.findAll(vocabulary);
+        final List<TermDto> allTerms = termService.findAllWithDefinition(vocabulary);
         getTransitivelyImportedVocabularies(vocabulary)
                 .forEach(importedVocabulary ->
-                        allTerms.addAll(termService.findAll(getReference(importedVocabulary))));
+                        allTerms.addAll(termService.findAllWithDefinition(getReference(importedVocabulary))));
 
         final Map<URI, List<AbstractTerm>> contextToTerms = new HashMap<>(allTerms.size());
         allTerms.forEach(t -> contextToTerms

--- a/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/VocabularyService.java
@@ -355,15 +355,15 @@ public class VocabularyService
      * Runs text analysis on the definitions of all terms in the specified vocabulary, including terms in the
      * transitively imported vocabularies.
      *
-     * @param vocabulary Vocabulary to be analyzed
+     * @param vocabularyUri Vocabulary to be analyzed
      */
     @Transactional
-    @Throttle(value = "{#vocabulary.getUri()}",
-              group = "T(ThrottleGroupProvider).getTextAnalysisVocabularyAllTerms(#vocabulary.getUri())",
+    @Throttle(value = "{#vocabularyUri}",
+              group = "T(ThrottleGroupProvider).getTextAnalysisVocabularyAllTerms(#vocabularyUri)",
               name = "allTermsVocabularyAnalysis")
-    @PreAuthorize("@vocabularyAuthorizationService.canModify(#vocabulary)")
-    public void runTextAnalysisOnAllTerms(URI vocabualryUri) {
-        final Vocabulary vocabulary = findRequired(vocabualryUri); // required when throttling for persistent context
+    @PreAuthorize("@vocabularyAuthorizationService.canModify(#vocabularyUri)")
+    public void runTextAnalysisOnAllTerms(URI vocabularyUri) {
+        final Vocabulary vocabulary = findRequired(vocabularyUri); // required when throttling for persistent context
         LOG.debug("Analyzing definitions of all terms in vocabulary {} and vocabularies it imports.", vocabulary);
         SnapshotProvider.verifySnapshotNotModified(vocabulary);
         final List<TermDto> allTerms = termService.findAll(vocabulary);

--- a/src/main/java/cz/cvut/kbss/termit/service/document/TextAnalysisService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/TextAnalysisService.java
@@ -87,10 +87,12 @@ public class TextAnalysisService {
      * Used for prefixing each merged term definition merged into a single input for text analysis.
      */
     private static final String TERM_DEFINITION_PREFIX = "<termdefinition id=\"";
+
     /**
      * Used for suffixing each merged term definition merged into a single input for text analysis.
      */
     private static final String TERM_DEFINITION_SUFFIX = "</termdefinition>";
+
     /**
      * Matches term definitions surrounded by {@link #TERM_DEFINITION_PREFIX} and {@link #TERM_DEFINITION_SUFFIX}.
      * <p>
@@ -100,7 +102,7 @@ public class TextAnalysisService {
      *     <li>Term definition</li>
      * </ol>
      */
-    private static final Pattern TERM_DEFINITION_PATTERN = Pattern.compile(TERM_DEFINITION_PREFIX + "([^\\\"]+)\" *\\>(.+?)" + TERM_DEFINITION_SUFFIX);
+    private static final Pattern TERM_DEFINITION_PATTERN = Pattern.compile(Pattern.quote(TERM_DEFINITION_PREFIX) + "([^\\\"]+)\" *\\>(.+?)" + Pattern.quote(TERM_DEFINITION_SUFFIX));
 
     @Autowired
     public TextAnalysisService(RestTemplate restClient, Configuration config, DocumentManager documentManager,

--- a/src/main/java/cz/cvut/kbss/termit/service/document/TextAnalysisService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/TextAnalysisService.java
@@ -84,12 +84,12 @@ public class TextAnalysisService {
     private Set<String> supportedLanguages;
 
     /**
-     * Used for prefixing each merged term definition merged into a single input for text analysis.
+     * Used for prefixing each term definition merged into a single input for text analysis.
      */
     private static final String TERM_DEFINITION_PREFIX = "<termdefinition id=\"";
 
     /**
-     * Used for suffixing each merged term definition merged into a single input for text analysis.
+     * Used for suffixing each term definition merged into a single input for text analysis.
      */
     private static final String TERM_DEFINITION_SUFFIX = "</termdefinition>";
 

--- a/src/main/java/cz/cvut/kbss/termit/service/document/TextAnalysisService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/TextAnalysisService.java
@@ -46,17 +46,23 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 @Service
 public class TextAnalysisService {
@@ -76,6 +82,25 @@ public class TextAnalysisService {
     private final ApplicationEventPublisher eventPublisher;
 
     private Set<String> supportedLanguages;
+
+    /**
+     * Used for prefixing each merged term definition merged into a single input for text analysis.
+     */
+    private static final String TERM_DEFINITION_PREFIX = "<termdefinition id=\"";
+    /**
+     * Used for suffixing each merged term definition merged into a single input for text analysis.
+     */
+    private static final String TERM_DEFINITION_SUFFIX = "</termdefinition>";
+    /**
+     * Matches term definitions surrounded by {@link #TERM_DEFINITION_PREFIX} and {@link #TERM_DEFINITION_SUFFIX}.
+     * <p>
+     * Outputs two groups:
+     * <ol>
+     *     <li>Term URI</li>
+     *     <li>Term definition</li>
+     * </ol>
+     */
+    private static final Pattern TERM_DEFINITION_PATTERN = Pattern.compile(TERM_DEFINITION_PREFIX + "([^\\\"]+)\" *\\>(.+?)" + TERM_DEFINITION_SUFFIX);
 
     @Autowired
     public TextAnalysisService(RestTemplate restClient, Configuration config, DocumentManager documentManager,
@@ -215,6 +240,14 @@ public class TextAnalysisService {
         }
     }
 
+    /**
+     * Invokes text analysis with the specified input.
+     * <p>
+     * The analysis result is passed to the annotation generator with the given term.
+     *
+     * @param term  Term whose definition is to be analyzed.
+     * @param input TextAnalysisInput containing the term definition and other necessary information.
+     */
     private void invokeTextAnalysisOnTerm(AbstractTerm term, TextAnalysisInput input) {
         try {
             final Optional<Resource> result = invokeTextAnalysisService(input);
@@ -234,6 +267,126 @@ public class TextAnalysisService {
             throw new WebServiceIntegrationException("Unable to read text analysis result from response.", e);
         }
     }
+
+    /**
+     * Combines the definitions of the given terms into a single string.
+     * <p>
+     * Each term definition is prefixed ({@link #TERM_DEFINITION_PREFIX}) and suffixed ({@link #TERM_DEFINITION_SUFFIX}).
+     * The combined definitions are returned as a single string.
+     * <p>
+     * The termMap is populated with the terms and their URIs.
+     *
+     * @param terms   List of terms whose definitions are to be combined.
+     * @param termMap Map to store the terms and their URIs.
+     * @return A string containing all combined term definitions.
+     */
+    private String combineTermDefinitions(List<AbstractTerm> terms, Map<URI, AbstractTerm> termMap) {
+        final StringBuilder definitions = new StringBuilder();
+        terms.forEach(term -> {
+            if (term.getDefinition() != null && term.getDefinition()
+                                                    .contains(config.getPersistence().getLanguage())) {
+                definitions.append(TERM_DEFINITION_PREFIX).append(term.getUri()).append("\">");
+                definitions.append(term.getDefinition().get(config.getPersistence().getLanguage()));
+                definitions.append(TERM_DEFINITION_SUFFIX);
+            }
+            termMap.put(term.getUri(), term);
+        });
+        return definitions.toString();
+    }
+
+    /**
+     * Analyzes term definitions for the given context-to-terms map.
+     * <p>
+     * Text analysis is invoked on all definitions merged for better efficiency.
+     *
+     * @param contextToTerms Map of vocabulary context URIs to lists of terms.
+     */
+    public void analyzeTermDefinitions(Map<URI, List<AbstractTerm>> contextToTerms) {
+        final var definitionsMap = new HashMap<URI, String>();
+        // map of term URI to respective term
+        // allows fast lookups by URI when generating annotations for each term
+        final var termMap = new HashMap<URI, AbstractTerm>();
+        // merge term definitions for each context and populate termMap
+        contextToTerms.forEach((context, terms) -> {
+            final String definitions = combineTermDefinitions(terms, termMap);
+            if (!definitions.isEmpty()) {
+                definitionsMap.put(context, definitions);
+            }
+        });
+
+        // invoke text analysis and generate annotations
+        definitionsMap.forEach((context, definitions) ->
+                invokeTextAnalysisOnCombinedDefinitions(context, definitions, termMap)
+        );
+    }
+
+    /**
+     * Generates annotations for the combined term definitions.
+     * <p>
+     * Parses the result string to extract term definitions and generates annotations for each term.
+     * Publishes an event for each term definition analysis completion.
+     *
+     * @param combinedResult The result of text analysis for combined term definitions.
+     * @param termMap        Map of term URIs to terms.
+     * @see #TERM_DEFINITION_PATTERN
+     */
+    private void generateAnnotationsForCombinedResult(String combinedResult, Map<URI, AbstractTerm> termMap) {
+        final var matcher = TERM_DEFINITION_PATTERN.matcher(combinedResult);
+        while (matcher.find()) {
+            // skip if the pattern does not match the expected groups
+            if (matcher.groupCount() != 2) {
+                continue;
+            }
+            final String termid = matcher.group(1);
+            final String termDefinition = matcher.group(2);
+            final var term = termMap.get(URI.create(termid));
+            annotationGenerator.generateAnnotations(new ByteArrayInputStream(termDefinition.getBytes(StandardCharsets.UTF_8)), term);
+            eventPublisher.publishEvent(new TermDefinitionTextAnalysisFinishedEvent(this, term));
+        }
+    }
+
+    /**
+     * Invokes text analysis on the combined definitions for a given context.
+     * <p>
+     * Sends the combined definitions to the text analysis service and processes the result.
+     * Generates annotations for the combined result.
+     *
+     * @param context     The vocabulary context URI.
+     * @param definitions The combined term definitions.
+     * @param termMap     Map of term URIs to terms.
+     */
+    private void invokeTextAnalysisOnCombinedDefinitions(URI context, String definitions,
+                                                         Map<URI, AbstractTerm> termMap) {
+        final TextAnalysisInput input = new TextAnalysisInput(
+                definitions,
+                config.getPersistence().getLanguage(),
+                URI.create(config.getRepository().getUrl())
+        );
+        input.addVocabularyContext(context);
+        input.setVocabularyRepositoryUserName(config.getRepository().getUsername());
+        input.setVocabularyRepositoryPassword(config.getRepository().getPassword());
+        try {
+            final Optional<Resource> result = invokeTextAnalysisService(input);
+            if (result.isEmpty()) {
+                return;
+            }
+            String resultString;
+            // consume the input stream and create a string
+            try (final InputStream is = result.get().getInputStream()) {
+                resultString = StreamUtils.copyToString(is, StandardCharsets.UTF_8);
+            }
+            generateAnnotationsForCombinedResult(resultString, termMap);
+        } catch (WebServiceIntegrationException e) {
+            throw e;
+        } catch (HttpClientErrorException e) {
+            throw handleTextAnalysisInvocationClientException(e, null);
+        } catch (RuntimeException e) {
+            throw new WebServiceIntegrationException("Text analysis invocation failed.", e);
+        } catch (IOException e) {
+            throw new WebServiceIntegrationException("Unable to read text analysis result from response.", e);
+        }
+    }
+
 
     /**
      * Checks whether the text analysis service supports the language of the specified file.

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -217,6 +217,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
      * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
      * @return List of vocabulary term DTOs ordered by label
      */
+    @Transactional(readOnly = true)
     public List<TermDto> findAllWithDefinition(Vocabulary vocabulary) {
         return termDao.findAllWithDefinition(vocabulary);
     }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -213,6 +213,8 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
     /**
      * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy.
      * Filters terms that have label and definition in the instance language.
+     * <p>
+     * Terms are loaded <b>without</b> their subterms.
      *
      * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
      * @return List of vocabulary term DTOs ordered by label

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -211,6 +211,17 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
     }
 
     /**
+     * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy.
+     * Filters terms that have label and definition in the instance language.
+     *
+     * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
+     * @return List of vocabulary term DTOs ordered by label
+     */
+    public List<TermDto> findAllWithDefinition(Vocabulary vocabulary) {
+        return termDao.findAllWithDefinition(vocabulary);
+    }
+
+    /**
      * Gets all terms from a vocabulary, regardless of their position in the term hierarchy.
      * <p>
      * This returns the full versions of all terms (complete metadata) contained in a vocabulary's glossary and thus its

--- a/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/VocabularyControllerTest.java
@@ -69,7 +69,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -415,9 +414,9 @@ class VocabularyControllerTest extends BaseControllerTestRunner {
     void runTextAnalysisOnAllTermsInvokesTextAnalysisOnAllTermsFromService() throws Exception {
         final Vocabulary vocabulary = generateVocabulary();
         vocabulary.setUri(VOCABULARY_URI);
-        when(sut.getById(FRAGMENT, Optional.of(NAMESPACE))).thenReturn(vocabulary);
+        when(idResolverMock.resolveIdentifier(null, FRAGMENT)).thenReturn(vocabulary.getUri());
         mockMvc.perform(put(PATH + "/" + FRAGMENT + "/terms/text-analysis")).andExpect(status().isAccepted());
-        verify(serviceMock).runTextAnalysisOnAllTerms(vocabulary);
+        verify(serviceMock).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -320,19 +320,18 @@ class TermServiceTest {
 
     @Test
     void persistChildInvokesTextAnalysisOnAllTermsInVocabulary() {
-        when(vocabularyService.findRequired(vocabulary.getUri())).thenReturn(vocabulary);
         final Term parent = generateTermWithId();
         parent.setVocabulary(vocabulary.getUri());
         final Term childToPersist = generateTermWithId();
         sut.persistChild(childToPersist, parent);
-        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary);
+        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test
     void persistRootInvokesTextAnalysisOnAllTermsInVocabulary() {
         final Term toPersist = generateTermWithId();
         sut.persistRoot(toPersist, vocabulary);
-        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary);
+        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test
@@ -360,9 +359,8 @@ class TermServiceTest {
         toUpdate.setDefinition(MultilingualString.create(newDefinition, Environment.LANGUAGE));
         when(termRepositoryService.findRequired(toUpdate.getUri())).thenReturn(original);
         when(termRepositoryService.update(toUpdate)).thenReturn(toUpdate);
-        when(vocabularyService.getReference(vocabulary.getUri())).thenReturn(vocabulary);
         sut.update(toUpdate);
-        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary);
+        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test
@@ -466,7 +464,7 @@ class TermServiceTest {
         sut.persistRoot(term, vocabulary);
         final InOrder inOrder = inOrder(termRepositoryService, vocabularyService);
         inOrder.verify(termRepositoryService).addRootTermToVocabulary(term, vocabulary);
-        inOrder.verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary);
+        inOrder.verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test
@@ -474,12 +472,11 @@ class TermServiceTest {
         final Term parent = generateTermWithId();
         parent.setVocabulary(vocabulary.getUri());
         final Term childToPersist = generateTermWithId();
-        when(vocabularyService.findRequired(vocabulary.getUri())).thenReturn(vocabulary);
 
         sut.persistChild(childToPersist, parent);
         final InOrder inOrder = inOrder(termRepositoryService, vocabularyService);
         inOrder.verify(termRepositoryService).addChildTerm(childToPersist, parent);
-        inOrder.verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary);
+        inOrder.verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test
@@ -491,12 +488,11 @@ class TermServiceTest {
         update.setDescription(new MultilingualString(original.getDescription().getValue()));
         update.setVocabulary(vocabulary.getUri());
         when(termRepositoryService.findRequired(original.getUri())).thenReturn(original);
-        when(vocabularyService.getReference(vocabulary.getUri())).thenReturn(vocabulary);
         when(termRepositoryService.update(update)).thenReturn(update);
         update.getLabel().set(Environment.LANGUAGE, "updatedLabel");
 
         sut.update(update);
-        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary);
+        verify(vocabularyService).runTextAnalysisOnAllTerms(vocabulary.getUri());
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
@@ -128,7 +128,7 @@ class VocabularyServiceTest {
         final Term termOne = Generator.generateTermWithId(vocabulary.getUri());
         final Term termTwo = Generator.generateTermWithId(vocabulary.getUri());
         List<TermDto> terms = termsToDtos(Arrays.asList(termOne, termTwo));
-        when(termService.findAll(vocabulary)).thenReturn(terms);
+        when(termService.findAllWithDefinition(vocabulary)).thenReturn(terms);
         when(contextMapper.getVocabularyContext(vocabulary.getUri())).thenReturn(vocabulary.getUri());
         when(repositoryService.getTransitivelyImportedVocabularies(vocabulary)).thenReturn(Collections.emptyList());
         when(repositoryService.findRequired(vocabulary.getUri())).thenReturn(vocabulary);
@@ -161,8 +161,8 @@ class VocabularyServiceTest {
         when(repositoryService.findAll()).thenReturn(vocabularies);
         when(contextMapper.getVocabularyContext(v.getUri())).thenReturn(v.getUri());
 
-        when(termService.findAll(v)).thenReturn(terms);
-        when(termService.findAll(vv)).thenReturn(terms2);
+        when(termService.findAllWithDefinition(v)).thenReturn(terms);
+        when(termService.findAllWithDefinition(vv)).thenReturn(terms2);
         sut.runTextAnalysisOnAllVocabularies();
 
         verify(termService, times(vocabularies.size())).analyzeTermDefinitions(notNull());

--- a/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
@@ -27,6 +27,7 @@ import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.event.VocabularyContentModifiedEvent;
 import cz.cvut.kbss.termit.event.VocabularyCreatedEvent;
 import cz.cvut.kbss.termit.exception.NotFoundException;
+import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.acl.AccessControlList;
@@ -59,15 +60,19 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static cz.cvut.kbss.termit.environment.Environment.termsToDtos;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -77,6 +82,7 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -117,7 +123,7 @@ class VocabularyServiceTest {
     }
 
     @Test
-    void runTextAnalysisOnAllTermsInvokesTextAnalysisOnAllTermsInVocabulary() {
+    void runTextAnalysisOnAllTermsInvokesAnalyzeTermDefinitionsWithAllTerms() {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         final Term termOne = Generator.generateTermWithId(vocabulary.getUri());
         final Term termTwo = Generator.generateTermWithId(vocabulary.getUri());
@@ -127,22 +133,39 @@ class VocabularyServiceTest {
         when(repositoryService.getTransitivelyImportedVocabularies(vocabulary)).thenReturn(Collections.emptyList());
         when(repositoryService.findRequired(vocabulary.getUri())).thenReturn(vocabulary);
         sut.runTextAnalysisOnAllTerms(vocabulary.getUri());
-        verify(termService).analyzeTermDefinitions(notNull());
+
+        final ArgumentCaptor<Map<URI, List<AbstractTerm>>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(termService).analyzeTermDefinitions(captor.capture());
+
+        final Map<URI, List<AbstractTerm>> contextToTerms = captor.getValue();
+        assertEquals(1, contextToTerms.size());
+        assertIterableEquals(terms, contextToTerms.get(vocabulary.getUri()));
     }
 
     @Test
-    void runTextAnalysisOnAllTermsInvokesTextAnalysisOnAllVocabularies() {
+    void runTextAnalysisOnAllVocabulariesInvokesAnalyzeTermDefinitionsForEachVocabulary() {
         final Vocabulary v = Generator.generateVocabularyWithId();
-        final List<VocabularyDto> vocabularies = Collections.singletonList(Environment.getDtoMapper()
-                                                                                      .vocabularyToVocabularyDto(v));
-        final Term term = Generator.generateTermWithId(v.getUri());
+        final Vocabulary vv = Generator.generateVocabularyWithId();
+
+        final List<VocabularyDto> vocabularies = List.of(Environment.getDtoMapper().vocabularyToVocabularyDto(v),
+                Environment.getDtoMapper().vocabularyToVocabularyDto(vv));
+
+        final List<TermDto> terms = Stream.of(Generator.generateTermWithId(v.getUri()), Generator.generateTermWithId(v.getUri()))
+                                          .map(TermDto::new).toList();
+        final List<TermDto> terms2 = Stream.of(Generator.generateTermWithId(vv.getUri()), Generator.generateTermWithId(vv.getUri()))
+                                           .map(TermDto::new).toList();
+
         when(repositoryService.findRequired(v.getUri())).thenReturn(v);
+        when(repositoryService.findRequired(vv.getUri())).thenReturn(vv);
+
         when(repositoryService.findAll()).thenReturn(vocabularies);
         when(contextMapper.getVocabularyContext(v.getUri())).thenReturn(v.getUri());
-        when(termService.findAll(v)).thenReturn(Collections.singletonList(new TermDto(term)));
+
+        when(termService.findAll(v)).thenReturn(terms);
+        when(termService.findAll(vv)).thenReturn(terms2);
         sut.runTextAnalysisOnAllVocabularies();
 
-        verify(termService).analyzeTermDefinitions(any());
+        verify(termService, times(vocabularies.size())).analyzeTermDefinitions(notNull());
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
@@ -71,6 +71,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.atLeastOnce;
@@ -126,8 +127,7 @@ class VocabularyServiceTest {
         when(repositoryService.getTransitivelyImportedVocabularies(vocabulary)).thenReturn(Collections.emptyList());
         when(repositoryService.findRequired(vocabulary.getUri())).thenReturn(vocabulary);
         sut.runTextAnalysisOnAllTerms(vocabulary);
-        verify(termService).analyzeTermDefinition(termOne, vocabulary.getUri());
-        verify(termService).analyzeTermDefinition(termTwo, vocabulary.getUri());
+        verify(termService).analyzeTermDefinitions(notNull());
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/VocabularyServiceTest.java
@@ -126,7 +126,7 @@ class VocabularyServiceTest {
         when(contextMapper.getVocabularyContext(vocabulary.getUri())).thenReturn(vocabulary.getUri());
         when(repositoryService.getTransitivelyImportedVocabularies(vocabulary)).thenReturn(Collections.emptyList());
         when(repositoryService.findRequired(vocabulary.getUri())).thenReturn(vocabulary);
-        sut.runTextAnalysisOnAllTerms(vocabulary);
+        sut.runTextAnalysisOnAllTerms(vocabulary.getUri());
         verify(termService).analyzeTermDefinitions(notNull());
     }
 
@@ -136,12 +136,13 @@ class VocabularyServiceTest {
         final List<VocabularyDto> vocabularies = Collections.singletonList(Environment.getDtoMapper()
                                                                                       .vocabularyToVocabularyDto(v));
         final Term term = Generator.generateTermWithId(v.getUri());
+        when(repositoryService.findRequired(v.getUri())).thenReturn(v);
         when(repositoryService.findAll()).thenReturn(vocabularies);
         when(contextMapper.getVocabularyContext(v.getUri())).thenReturn(v.getUri());
         when(termService.findAll(v)).thenReturn(Collections.singletonList(new TermDto(term)));
         sut.runTextAnalysisOnAllVocabularies();
 
-        verify(termService).analyzeTermDefinition(term, v.getUri());
+        verify(termService).analyzeTermDefinitions(any());
     }
 
     @Test


### PR DESCRIPTION
Resolves #327 

Text analysis of all terms inside a vocabulary will now merge definitions of all terms and invoke text analysis only once (per context).

Each merged term definition is wrapped with `termdefinition` tag.
```html
<termdefinition id="http://resource.identifier/term">
This is term definition
</termdefinition>
```

The result of text analysis is then processed with regex, extracting individual definitions and term IDs.  
Each annotated definition is then passed along with the term to the annotation generator individually.

Loading all the terms from a vocabulary will still take a decent amount of time.