### PR TITLE
Bug#329 prevent self referencing terms

### DIFF
--- a/src/test/resources/data/test-glossary-self-referencing-terms.ttl
+++ b/src/test/resources/data/test-glossary-self-referencing-terms.ttl
@@ -1,0 +1,33 @@
+@prefix termit: <http://onto.fel.cvut.cz/ontologies/application/termit/> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix termit-pojem: <http://onto.fel.cvut.cz/ontologies/application/termit/pojem/> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+
+termit:glosář  a        owl:Ontology , <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/glosář> , skos:ConceptScheme ;
+        <http://purl.org/dc/terms/creator>
+                " Martin Ledvinka" , "Michal Med" ;
+        <http://purl.org/dc/terms/title>
+                "Vocabulary of system TermIt - glossary"@en , "Slovník systému TermIt - glosář"@cs ;
+        <http://purl.org/dc/terms/description>
+                "This is a test version of the vocabulary of TermIt"@en , "Toto je testovací verze slovníku systému TermIt"@cs ;
+        <http://purl.org/dc/terms/created>
+                "25.04.2019" ;
+        owl:versionIRI  <http://onto.fel.cvut.cz/ontologies/application/termit/glosář/verze/1.1.1> .
+
+termit-pojem:uživatel-termitu
+        a       skos:Concept ;
+        skos:broader
+                <https://slovník.gov.cz/základní/pojem/typ-objektu> ;
+        skos:inScheme
+                termit:glosář ;
+        skos:prefLabel
+                "TermIt user"@en , "Uživatel TermItu"@cs ;
+        skos:related
+                termit-pojem:uživatel-termitu ;
+        skos:relatedMatch
+                termit-pojem:uživatel-termitu ;
+        skos:exactMatch
+                termit-pojem:uživatel-termitu .


### PR DESCRIPTION
Prevents #329.

The issue was caused by self-referencing terms. Beside cleaning up existing data, this PR adds checks for self-referencing to SKOS/Excel import.