### PR TITLE
[kbss-cvut/termit-ui#655] Evict FlatTermDto from JOPA 2nd-level cache…

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/AssetDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/AssetDao.java
@@ -125,16 +125,12 @@ public class AssetDao {
     }
 
     private String insertVocabularyPattern(AssetWithType elem) {
-        switch (elem.type.toString()) {
-            case SKOS.CONCEPT:
-                return "?ent ?isFromVocabulary ?vocabulary . ";
-            case Vocabulary.s_c_dokument:
-                return "?ent ?hasVocabulary ?vocabulary . ";
-            case Vocabulary.s_c_soubor:
-                return "?ent ?inDocument/?hasVocabulary ?vocabulary . ";
-            default:
-                return "BIND (?ent as ?vocabulary)";
-        }
+        return switch (elem.type.toString()) {
+            case SKOS.CONCEPT -> "?ent ?isFromVocabulary ?vocabulary . ";
+            case Vocabulary.s_c_dokument -> "?ent ?hasVocabulary ?vocabulary . ";
+            case Vocabulary.s_c_soubor -> "?ent ?inDocument/?hasVocabulary ?vocabulary . ";
+            default -> "BIND (?ent as ?vocabulary)";
+        };
     }
 
     private void setVocabularyRelatedParameter(AssetWithType elem, Query query) {
@@ -210,13 +206,6 @@ public class AssetDao {
         }
     }
 
-    private static final class AssetWithType {
-        private final URI uri;
-        private final URI type;
-
-        private AssetWithType(URI uri, URI type) {
-            this.uri = uri;
-            this.type = type;
-        }
+    private record AssetWithType(URI uri, URI type) {
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -267,6 +267,7 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
         em.getEntityManagerFactory().getCache().evict(Term.class, term.getUri(), null);
         em.getEntityManagerFactory().getCache().evict(TermDto.class, term.getUri(), null);
         em.getEntityManagerFactory().getCache().evict(TermInfo.class, term.getUri(), null);
+        em.getEntityManagerFactory().getCache().evict(FlatTermDto.class, term.getUri(), null);
         Utils.emptyIfNull(term.getParentTerms()).forEach(t -> subTermsCache.evict(t.getUri()));
         Utils.emptyIfNull(term.getExternalParentTerms()).forEach(t -> subTermsCache.evict(t.getUri()));
         // Should be replaced by implementation of https://github.com/kbss-cvut/jopa/issues/92

--- a/src/main/java/cz/cvut/kbss/termit/service/changetracking/ChangeTracker.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/changetracking/ChangeTracker.java
@@ -73,8 +73,7 @@ public class ChangeTracker {
      * <p>
      * Each changed attribute is stored as a separate change record
      *
-     * @param update   The updated version of the asset
-     * @param original The original version of the asset
+     * @param event Event representing the asset update
      */
     @Transactional
     @EventListener(AssetUpdateEvent.class)


### PR DESCRIPTION
Fixes kbss-cvut/termit-ui#655.

Changes in `AssetDao` are only code polish, they are not related to the fixed issue.