### PR TITLE
[kbss-cvut/termit-ui#659] Restrict full-text search language selection to available languages

### DIFF
--- a/ontology/termit-glosář.ttl
+++ b/ontology/termit-glosář.ttl
@@ -476,6 +476,15 @@ termit-pojem:má-maximální-velikost-souboru
         <http://www.w3.org/2004/02/skos/core#prefLabel>
                 "Has maximum file size"@en , "Má maximální velikost souboru"@cs .
 
+termit-pojem:má-indexovaný-jazyk
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+                <https://slovník.gov.cz/základní/pojem/vlastnost> , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+                termit:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+                "Has indexed language"@en , "Má indexovaný jazyk"@cs .
+
 termit-pojem:má-oddělovač-verze
         a       <http://www.w3.org/2004/02/skos/core#Concept> ;
         <http://www.w3.org/2004/02/skos/core#broader>

--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -256,6 +256,10 @@ termit-pojem:má-maximální-velikost-souboru
         a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
         rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .
 
+termit-pojem:má-indexovaný-jazyk
+        a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
+        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .
+
 termit-pojem:má-oddělovač-verze
         a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
         rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .

--- a/src/main/java/cz/cvut/kbss/termit/dto/ConfigurationDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/ConfigurationDto.java
@@ -56,6 +56,9 @@ public class ConfigurationDto implements Serializable {
     @OWLAnnotationProperty(iri = Vocabulary.s_p_ma_adresu_modelovaciho_nastroje)
     private String modelingToolUrl;
 
+    @OWLDataProperty(iri = Vocabulary.s_p_ma_indexovany_jazyk)
+    private Set<String> indexedLanguages = Set.of();
+
     public String getLanguage() {
         return language;
     }
@@ -102,5 +105,13 @@ public class ConfigurationDto implements Serializable {
 
     public void setModelingToolUrl(String modelingToolUrl) {
         this.modelingToolUrl = modelingToolUrl;
+    }
+
+    public Set<String> getIndexedLanguages() {
+        return indexedLanguages;
+    }
+
+    public void setIndexedLanguages(Set<String> indexedLanguages) {
+        this.indexedLanguages = indexedLanguages;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/config/ConfigurationProvider.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/config/ConfigurationProvider.java
@@ -18,6 +18,7 @@
 package cz.cvut.kbss.termit.service.config;
 
 import cz.cvut.kbss.termit.dto.ConfigurationDto;
+import cz.cvut.kbss.termit.service.init.lucene.GraphDBLuceneConnectorInitializer;
 import cz.cvut.kbss.termit.service.repository.UserRoleRepositoryService;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Vocabulary;
@@ -38,13 +39,17 @@ public class ConfigurationProvider {
 
     private final UserRoleRepositoryService service;
 
+    private final GraphDBLuceneConnectorInitializer luceneConnectorInitializer;
+
     @Value("${spring.servlet.multipart.max-file-size}")
     private String maxFileUploadSize;
 
     @Autowired
-    public ConfigurationProvider(Configuration config, UserRoleRepositoryService service) {
+    public ConfigurationProvider(Configuration config, UserRoleRepositoryService service,
+                                 @Autowired(required = false) GraphDBLuceneConnectorInitializer luceneConnectorInitializer) {
         this.config = config;
         this.service = service;
+        this.luceneConnectorInitializer = luceneConnectorInitializer;
     }
 
     /**
@@ -60,6 +65,9 @@ public class ConfigurationProvider {
         result.setMaxFileUploadSize(maxFileUploadSize);
         result.setVersionSeparator(config.getNamespace().getSnapshot().getSeparator());
         result.setModelingToolUrl(config.getModelingToolUrl());
+        if (luceneConnectorInitializer != null) {
+            result.setIndexedLanguages(luceneConnectorInitializer.getIndexedLanguages());
+        }
         return result;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/config/ConfigurationProvider.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/config/ConfigurationProvider.java
@@ -18,7 +18,7 @@
 package cz.cvut.kbss.termit.service.config;
 
 import cz.cvut.kbss.termit.dto.ConfigurationDto;
-import cz.cvut.kbss.termit.service.init.lucene.GraphDBLuceneConnectorInitializer;
+import cz.cvut.kbss.termit.service.init.lucene.IndexedLanguagesProvider;
 import cz.cvut.kbss.termit.service.repository.UserRoleRepositoryService;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Vocabulary;
@@ -39,17 +39,17 @@ public class ConfigurationProvider {
 
     private final UserRoleRepositoryService service;
 
-    private final GraphDBLuceneConnectorInitializer luceneConnectorInitializer;
+    private final IndexedLanguagesProvider indexedLanguagesProvider;
 
     @Value("${spring.servlet.multipart.max-file-size}")
     private String maxFileUploadSize;
 
     @Autowired
     public ConfigurationProvider(Configuration config, UserRoleRepositoryService service,
-                                 @Autowired(required = false) GraphDBLuceneConnectorInitializer luceneConnectorInitializer) {
+                                 IndexedLanguagesProvider indexedLanguagesProvider) {
         this.config = config;
         this.service = service;
-        this.luceneConnectorInitializer = luceneConnectorInitializer;
+        this.indexedLanguagesProvider = indexedLanguagesProvider;
     }
 
     /**
@@ -65,9 +65,7 @@ public class ConfigurationProvider {
         result.setMaxFileUploadSize(maxFileUploadSize);
         result.setVersionSeparator(config.getNamespace().getSnapshot().getSeparator());
         result.setModelingToolUrl(config.getModelingToolUrl());
-        if (luceneConnectorInitializer != null) {
-            result.setIndexedLanguages(luceneConnectorInitializer.getIndexedLanguages());
-        }
+        result.setIndexedLanguages(indexedLanguagesProvider.getIndexedLanguages());
         return result;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/init/lucene/GraphDBLuceneConnectorInitializer.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/lucene/GraphDBLuceneConnectorInitializer.java
@@ -100,6 +100,7 @@ public class GraphDBLuceneConnectorInitializer {
     private final Set<URI> indexedFields;
     private final EntityManager em;
     private final ObjectMapper mapper;
+    private Set<String> indexedLanguages = Set.of();
 
     public GraphDBLuceneConnectorInitializer(EntityManager em, ObjectMapper mapper) {
         this.em = em;
@@ -367,12 +368,15 @@ public class GraphDBLuceneConnectorInitializer {
     public void initialize() {
         LOG.debug("Initializing Lucene Connectors");
         final Map<String, Set<LuceneConnector>> connectors = loadExistingConnectors();
-        final Set<String> languages = fetchUsedLanguages();
-        languages.add(""); // explicitly add empty language to force creation of universal index for all languages
-        for (String lang : languages) {
+        indexedLanguages = fetchUsedLanguages();
+        indexedLanguages.add(""); // explicitly add empty language to force creation of universal index for all languages
+        for (String lang : indexedLanguages) {
             handleRequiredConnectors(lang, connectors.getOrDefault(lang, Set.of()));
         }
         LOG.debug("Lucene Connectors initialized");
     }
 
+    public Set<String> getIndexedLanguages() {
+        return indexedLanguages;
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/init/lucene/GraphDBLuceneConnectorInitializer.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/lucene/GraphDBLuceneConnectorInitializer.java
@@ -77,7 +77,7 @@ Alternative would be adding lucene dependency and listing the analyzer classes a
  */
 @Service
 @Profile("!test")
-public class GraphDBLuceneConnectorInitializer {
+public class GraphDBLuceneConnectorInitializer implements IndexedLanguagesProvider {
     static final URI LUCENE_LIST_CONNECTORS = URI.create("http://www.ontotext.com/connectors/lucene#listConnectors");
     static final URI LUCENE_LIST_OPTION_VALUES = URI.create("http://www.ontotext.com/connectors/lucene#listOptionValues");
     static final URI LUCENE_DROP_CONNECTOR = URI.create("http://www.ontotext.com/connectors/lucene#dropConnector");
@@ -376,6 +376,7 @@ public class GraphDBLuceneConnectorInitializer {
         LOG.debug("Lucene Connectors initialized");
     }
 
+    @Override
     public Set<String> getIndexedLanguages() {
         return indexedLanguages;
     }

--- a/src/main/java/cz/cvut/kbss/termit/service/init/lucene/IndexedLanguagesProvider.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/init/lucene/IndexedLanguagesProvider.java
@@ -1,0 +1,10 @@
+package cz.cvut.kbss.termit.service.init.lucene;
+
+import java.util.Set;
+
+/**
+ * Provides list of currently indexed languages for Full Text Search
+ */
+public interface IndexedLanguagesProvider {
+    Set<String> getIndexedLanguages();
+}

--- a/src/test/java/cz/cvut/kbss/termit/environment/config/TestServiceConfig.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/config/TestServiceConfig.java
@@ -23,6 +23,7 @@ import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.model.selector.Selector;
 import cz.cvut.kbss.termit.service.document.html.DummySelectorGenerator;
 import cz.cvut.kbss.termit.service.document.html.HtmlSelectorGenerators;
+import cz.cvut.kbss.termit.service.init.lucene.IndexedLanguagesProvider;
 import cz.cvut.kbss.termit.util.Configuration;
 import org.jsoup.nodes.Element;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -107,5 +108,10 @@ public class TestServiceConfig {
     @Bean
     public DtoMapper dtoMapper() {
         return new DtoMapperImpl();
+    }
+
+    @Bean
+    public IndexedLanguagesProvider indexedLanguagesProvider() {
+        return Set::of;
     }
 }


### PR DESCRIPTION
resolves kbss-cvut/termit-ui#659
- Caches indexed languages in `GraphDBLuceneConnectorInitializer`
- Indexed languages are now included in the configuration endpoint available for the FE