### PR TITLE
[Enhancement #338] Limit the frequency of document file backup creation

### DIFF
--- a/ontology/termit-glosář.ttl
+++ b/ontology/termit-glosář.ttl
@@ -690,3 +690,11 @@ termit-pojem:vlastní-atribut
     <http://www.w3.org/2004/02/skos/core#prefLabel>
             "Custom attribute"@en , "Vlastní atribut"@cs .
 
+termit-pojem:má-datum-a-čas-poslední-zálohy
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+                <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-datum-a-čas-modifikace> , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+                termit:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+                "Has date and time of the last backup"@en , "Má datum a čas poslední zálohy"@cs .

--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -358,6 +358,7 @@ termit-pojem:vlastní-atribut
 
 termit-pojem:má-datum-a-čas-poslední-zálohy
         a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
-        rdfs:subPropertyOf  <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-datum-a-čas-modifikace> .
+        rdfs:subPropertyOf  <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-datum-a-čas-modifikace> ;
+        rdfs:range          xsd:dateTime .
 
 

--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -356,4 +356,8 @@ termit-pojem:vlastní-atribut
         a                owl:Class ;
         rdfs:subClassOf rdf:Property .
 
+termit-pojem:má-datum-a-čas-poslední-zálohy
+        a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
+        rdfs:subPropertyOf  <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-datum-a-čas-modifikace> .
+
 

--- a/src/main/java/cz/cvut/kbss/termit/model/resource/File.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/resource/File.java
@@ -49,7 +49,7 @@ public class File extends Resource implements SupportsStorage {
     private String language;
 
     @OWLDataProperty(iri = DC.Terms.MODIFIED)
-    private Instant lastModified;
+    private Instant modified;
 
     @Types
     private Set<String> types;
@@ -70,12 +70,12 @@ public class File extends Resource implements SupportsStorage {
         this.language = language;
     }
 
-    public Instant getLastModified() {
-        return lastModified;
+    public Instant getModified() {
+        return modified;
     }
 
-    public void setLastModified(Instant lastModified) {
-        this.lastModified = lastModified;
+    public void setModified(Instant modified) {
+        this.modified = modified;
     }
 
     public Set<String> getTypes() {
@@ -132,7 +132,11 @@ public class File extends Resource implements SupportsStorage {
         }
     }
 
-    public void updateLastModified() {
-        setLastModified(Utils.timestamp());
+    /**
+     * Sets the {@link #modified} to the current timestamp.
+     * @see Utils#timestamp()
+     */
+    public void updateModified() {
+        setModified(Utils.timestamp());
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/model/resource/File.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/resource/File.java
@@ -48,8 +48,11 @@ public class File extends Resource implements SupportsStorage {
     @OWLAnnotationProperty(iri = DC.Terms.LANGUAGE, simpleLiteral = true)
     private String language;
 
-    @OWLDataProperty(iri = DC.Terms.MODIFIED)
+    @OWLDataProperty(iri = Vocabulary.s_p_ma_datum_a_cas_posledni_modifikace)
     private Instant modified;
+
+    @OWLDataProperty(iri = Vocabulary.s_p_ma_datum_a_cas_posledni_zalohy)
+    private Instant lastBackup;
 
     @Types
     private Set<String> types;
@@ -76,6 +79,14 @@ public class File extends Resource implements SupportsStorage {
 
     public void setModified(Instant modified) {
         this.modified = modified;
+    }
+
+    public Instant getLastBackup() {
+        return lastBackup;
+    }
+
+    public void setLastBackup(Instant lastBackup) {
+        this.lastBackup = lastBackup;
     }
 
     public Set<String> getTypes() {
@@ -138,5 +149,13 @@ public class File extends Resource implements SupportsStorage {
      */
     public void updateModified() {
         setModified(Utils.timestamp());
+    }
+
+    /**
+     * Sets the {@link #lastBackup} to the current timestamp.
+     * @see Utils#timestamp()
+     */
+    public void updateLastBackup() {
+        setLastBackup(Utils.timestamp());
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/model/resource/File.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/resource/File.java
@@ -23,14 +23,17 @@ import cz.cvut.kbss.jopa.model.annotations.FetchType;
 import cz.cvut.kbss.jopa.model.annotations.Inferred;
 import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
 import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.model.annotations.Types;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
 import cz.cvut.kbss.termit.model.util.SupportsStorage;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
+import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.Vocabulary;
 
+import java.time.Instant;
 import java.util.Set;
 
 @OWLClass(iri = Vocabulary.s_c_soubor)
@@ -44,6 +47,9 @@ public class File extends Resource implements SupportsStorage {
 
     @OWLAnnotationProperty(iri = DC.Terms.LANGUAGE, simpleLiteral = true)
     private String language;
+
+    @OWLDataProperty(iri = DC.Terms.MODIFIED)
+    private Instant lastModified;
 
     @Types
     private Set<String> types;
@@ -62,6 +68,14 @@ public class File extends Resource implements SupportsStorage {
 
     public void setLanguage(String language) {
         this.language = language;
+    }
+
+    public Instant getLastModified() {
+        return lastModified;
+    }
+
+    public void setLastModified(Instant lastModified) {
+        this.lastModified = lastModified;
     }
 
     public Set<String> getTypes() {
@@ -116,5 +130,9 @@ public class File extends Resource implements SupportsStorage {
             final String labelPart = dotIndex > 0 ? getLabel().substring(0, getLabel().indexOf('.')) : getLabel();
             return IdentifierResolver.normalizeToAscii(labelPart) + '_' + getUri().hashCode();
         }
+    }
+
+    public void updateLastModified() {
+        setLastModified(Utils.timestamp());
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -24,6 +24,7 @@ import cz.cvut.kbss.termit.model.TextAnalysisRecord;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.model.resource.Resource;
+import cz.cvut.kbss.termit.rest.dto.ResourceSaveReason;
 import cz.cvut.kbss.termit.rest.util.RestUtils;
 import cz.cvut.kbss.termit.security.SecurityConstants;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
@@ -180,12 +181,15 @@ public class ResourceController extends BaseController {
                                                  example = ResourceControllerDoc.ID_NAMESPACE_EXAMPLE)
                                       @RequestParam(name = QueryParams.NAMESPACE,
                                                     required = false) Optional<String> namespace,
+                                      @Parameter(description = "The reason for saving the resource")
+                                      @RequestParam(name = "reason", required = false)
+                                                 Optional<ResourceSaveReason> reason,
                                       @Parameter(description = "File with the new content.")
                                       @RequestParam(name = "file") MultipartFile attachment) {
 
         final Resource resource = getResource(localName, namespace);
         try {
-            resourceService.saveContent(resource, attachment.getInputStream());
+            resourceService.saveContent(resource, attachment.getInputStream(), reason.orElse(ResourceSaveReason.UNKNOWN));
         } catch (IOException e) {
             throw new TermItException("Unable to read file (fileName=\"" + attachment.getOriginalFilename() + "\") content from request.", e);
         }

--- a/src/main/java/cz/cvut/kbss/termit/rest/dto/ResourceSaveReason.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/dto/ResourceSaveReason.java
@@ -1,13 +1,31 @@
 package cz.cvut.kbss.termit.rest.dto;
 
+import cz.cvut.kbss.termit.service.document.backup.BackupReason;
+
+import java.util.Optional;
+
 /**
  * Reason for saving a resource
  */
 public enum ResourceSaveReason {
-    NEW_OCCURRENCE,
-    REMOVE_OCCURRENCE,
+    NEW_OCCURRENCE(BackupReason.NEW_OCCURRENCE),
+    REMOVE_OCCURRENCE(BackupReason.REMOVE_OCCURRENCE),
     OCCURRENCE_STATE_CHANGE,
     CREATE_FILE,
-    REUPLOAD,
-    UNKNOWN
+    REUPLOAD(BackupReason.REUPLOAD),
+    UNKNOWN;
+
+    private final BackupReason backupReason;
+
+    ResourceSaveReason(BackupReason backupReason) {
+        this.backupReason = backupReason;
+    }
+
+    ResourceSaveReason() {
+        this.backupReason = null;
+    }
+
+    public Optional<BackupReason> getBackupReason() {
+        return Optional.ofNullable(backupReason);
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/dto/ResourceSaveReason.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/dto/ResourceSaveReason.java
@@ -1,0 +1,13 @@
+package cz.cvut.kbss.termit.rest.dto;
+
+/**
+ * Reason for saving a resource
+ */
+public enum ResourceSaveReason {
+    NEW_OCCURRENCE,
+    REMOVE_OCCURRENCE,
+    OCCURRENCE_STATE_CHANGE,
+    CREATE_FILE,
+    REUPLOAD,
+    UNKNOWN
+}

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -37,7 +37,6 @@ import cz.cvut.kbss.termit.service.changetracking.ChangeRecordProvider;
 import cz.cvut.kbss.termit.service.document.DocumentManager;
 import cz.cvut.kbss.termit.service.document.ResourceRetrievalSpecification;
 import cz.cvut.kbss.termit.service.document.TextAnalysisService;
-import cz.cvut.kbss.termit.service.document.backup.DocumentBackupManager;
 import cz.cvut.kbss.termit.service.document.html.UnconfirmedTermOccurrenceRemover;
 import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
@@ -193,6 +192,7 @@ public class ResourceService
      *
      * @param resource Domain resource associated with the content
      * @param content  Resource content
+     * @param saveReason Reason for saving the file content
      * @throws UnsupportedAssetOperationException If content saving is not supported for the specified resource
      */
     @Transactional
@@ -200,10 +200,11 @@ public class ResourceService
     public void saveContent(Resource resource, InputStream content, ResourceSaveReason saveReason) {
         Objects.requireNonNull(resource);
         Objects.requireNonNull(content);
+        Objects.requireNonNull(saveReason);
         verifyFileOperationPossible(resource, "Content saving");
         LOG.trace("Saving new content of resource {}.", resource);
         final File file = (File) resource;
-        DocumentBackupManager.mapSaveReasonToBackup(saveReason).ifPresent(backupReason -> {
+        saveReason.getBackupReason().ifPresent(backupReason -> {
             if (documentManager.exists(file)) {
                 documentManager.createBackup(file, backupReason);
             }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -259,7 +259,7 @@ public class ResourceService
             throw new TermItException("Document " + doc + " does not have a vocabulary.");
         }
         final Vocabulary vocabulary = vocabularyService.getReference(doc.getVocabulary());
-        file.updateLastModified();
+        file.updateModified();
         repositoryService.persist(file, vocabulary);
         repositoryService.update(doc);
     }

--- a/src/main/java/cz/cvut/kbss/termit/service/document/DefaultDocumentManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/DefaultDocumentManager.java
@@ -29,6 +29,7 @@ import cz.cvut.kbss.termit.service.document.backup.BackupFile;
 import cz.cvut.kbss.termit.service.document.backup.BackupReason;
 import cz.cvut.kbss.termit.service.document.backup.DocumentBackupManager;
 import cz.cvut.kbss.termit.service.document.backup.DocumentFileUtils;
+import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.TypeAwareFileSystemResource;
 import cz.cvut.kbss.termit.util.TypeAwareResource;
@@ -60,11 +61,14 @@ public class DefaultDocumentManager implements DocumentManager {
 
     private final Configuration configuration;
     private final DocumentBackupManager backupManager;
+    private final ResourceRepositoryService resourceRepositoryService;
 
     @Autowired
-    public DefaultDocumentManager(Configuration config, DocumentBackupManager backupManager) {
+    public DefaultDocumentManager(Configuration config, DocumentBackupManager backupManager,
+                                  ResourceRepositoryService resourceRepositoryService) {
         this.configuration = config;
         this.backupManager = backupManager;
+        this.resourceRepositoryService = resourceRepositoryService;
     }
 
     private Path storageDirectory() {
@@ -114,6 +118,8 @@ public class DefaultDocumentManager implements DocumentManager {
             LOG.debug("Saving file content to {}.", target);
             Files.createDirectories(target.getParentFile().toPath());
             Files.copy(content, target.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            file.updateLastModified();
+            resourceRepositoryService.update(file);
         } catch (IOException e) {
             throw new DocumentManagerException("Unable to write out file content.", e);
         }

--- a/src/main/java/cz/cvut/kbss/termit/service/document/DefaultDocumentManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/DefaultDocumentManager.java
@@ -118,7 +118,7 @@ public class DefaultDocumentManager implements DocumentManager {
             LOG.debug("Saving file content to {}.", target);
             Files.createDirectories(target.getParentFile().toPath());
             Files.copy(content, target.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            file.updateLastModified();
+            file.updateModified();
             resourceRepositoryService.update(file);
         } catch (IOException e) {
             throw new DocumentManagerException("Unable to write out file content.", e);

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/BackupReason.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/BackupReason.java
@@ -7,6 +7,7 @@ public enum BackupReason {
     REUPLOAD,
     TEXT_ANALYSIS,
     NEW_OCCURRENCE,
+    REMOVE_OCCURRENCE,
     SCHEDULED,
     BACKUP_RESTORE,
     UNKNOWN;

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/BackupReason.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/BackupReason.java
@@ -4,6 +4,7 @@ package cz.cvut.kbss.termit.service.document.backup;
  * The reason for creation of a document file backup
  */
 public enum BackupReason {
+    REUPLOAD,
     TEXT_ANALYSIS,
     NEW_OCCURRENCE,
     SCHEDULED,

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
@@ -3,6 +3,7 @@ package cz.cvut.kbss.termit.service.document.backup;
 import cz.cvut.kbss.termit.exception.BackupManagerException;
 import cz.cvut.kbss.termit.exception.NotFoundException;
 import cz.cvut.kbss.termit.model.resource.File;
+import cz.cvut.kbss.termit.rest.dto.ResourceSaveReason;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Utils;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -39,11 +41,23 @@ import java.util.stream.Stream;
 @Service
 public class DocumentBackupManager {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentBackupManager.class);
-
+    private static final Map<ResourceSaveReason, BackupReason> SAVE_REASONS_FOR_BACKUP = Map.of(
+            ResourceSaveReason.NEW_OCCURRENCE, BackupReason.NEW_OCCURRENCE,
+            ResourceSaveReason.REUPLOAD, BackupReason.REUPLOAD
+    );
     private final Path storageDirectory;
 
     public DocumentBackupManager(Configuration config) {
         this.storageDirectory = Path.of(config.getFile().getStorage());
+    }
+
+    /**
+     * Maps {@link ResourceSaveReason} to {@link BackupReason} if the backup should be created.
+     * @param saveReason The save reason to map
+     * @return The mapped value or empty optional if the backup should not be created.
+     */
+    public static Optional<BackupReason> mapSaveReasonToBackup(ResourceSaveReason saveReason) {
+        return Optional.ofNullable(SAVE_REASONS_FOR_BACKUP.get(saveReason));
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
@@ -3,7 +3,6 @@ package cz.cvut.kbss.termit.service.document.backup;
 import cz.cvut.kbss.termit.exception.BackupManagerException;
 import cz.cvut.kbss.termit.exception.NotFoundException;
 import cz.cvut.kbss.termit.model.resource.File;
-import cz.cvut.kbss.termit.rest.dto.ResourceSaveReason;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
 import cz.cvut.kbss.termit.util.Configuration;
@@ -34,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -43,26 +41,12 @@ import java.util.stream.Stream;
 @Service
 public class DocumentBackupManager {
     private static final Logger LOG = LoggerFactory.getLogger(DocumentBackupManager.class);
-    private static final Map<ResourceSaveReason, BackupReason> SAVE_REASONS_FOR_BACKUP = Map.of(
-            ResourceSaveReason.NEW_OCCURRENCE, BackupReason.NEW_OCCURRENCE,
-            ResourceSaveReason.REMOVE_OCCURRENCE, BackupReason.REMOVE_OCCURRENCE,
-            ResourceSaveReason.REUPLOAD, BackupReason.REUPLOAD
-    );
     private final Path storageDirectory;
     private final ResourceRepositoryService resourceRepositoryService;
 
     public DocumentBackupManager(Configuration config, ResourceRepositoryService resourceRepositoryService) {
         this.storageDirectory = Path.of(config.getFile().getStorage());
         this.resourceRepositoryService = resourceRepositoryService;
-    }
-
-    /**
-     * Maps {@link ResourceSaveReason} to {@link BackupReason} if the backup should be created.
-     * @param saveReason The save reason to map
-     * @return The mapped value or empty optional if the backup should not be created.
-     */
-    public static Optional<BackupReason> mapSaveReasonToBackup(ResourceSaveReason saveReason) {
-        return Optional.ofNullable(SAVE_REASONS_FOR_BACKUP.get(saveReason));
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentScheduledBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentScheduledBackupManager.java
@@ -1,0 +1,52 @@
+package cz.cvut.kbss.termit.service.document.backup;
+
+import cz.cvut.kbss.jopa.model.EntityManager;
+import cz.cvut.kbss.termit.model.resource.File;
+import cz.cvut.kbss.termit.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+public class DocumentScheduledBackupManager {
+    private static final Logger LOG = LoggerFactory.getLogger(DocumentScheduledBackupManager.class);
+    private final EntityManager em;
+    private final DocumentBackupManager backupManager;
+
+    public DocumentScheduledBackupManager(EntityManager em, DocumentBackupManager backupManager) {
+        this.em = em;
+        this.backupManager = backupManager;
+    }
+
+    /**
+     * Creates a scheduled backup of all document files modified in last 24 hours.
+     * <p>
+     * Every day at {@code 03:00}.
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    void backupModifiedDocuments() {
+        List<File> toBackup = findFilesModifiedSince(Utils.timestamp().minus(24, ChronoUnit.HOURS));
+        if (!toBackup.isEmpty()) {
+            LOG.info("Starting scheduled backup for {} document files", toBackup.size());
+        }
+        for (File file : toBackup) {
+            try {
+                backupManager.createBackup(file, BackupReason.SCHEDULED);
+            } catch (Exception e) {
+                LOG.error("Failed to create scheduled backup for file <{}>", file.getUri(), e);
+            }
+        }
+    }
+
+    List<File> findFilesModifiedSince(Instant since) {
+        return em.createQuery("SELECT DISTINCT f FROM File f WHERE f.modified > :since", File.class)
+                .setParameter("since", since)
+                .getResultList();
+    }
+
+}

--- a/src/test/java/cz/cvut/kbss/termit/environment/Generator.java
+++ b/src/test/java/cz/cvut/kbss/termit/environment/Generator.java
@@ -65,6 +65,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -547,5 +548,32 @@ public class Generator {
         result.add(ar);
 
         return result;
+    }
+
+    /**
+     * Generates {@link File Files} with different modification and last backup timestamps.
+     * Generated files are linked to the provided document.
+     * @param document the document to which the files should be added
+     * @return generated files
+     */
+    public static List<File> generateDocumentFilesWithBackupTimestamps(Document document) {
+        Instant now = Instant.now().minusSeconds(1);
+        return Map.of(now.minus(25, ChronoUnit.HOURS), now.minus(24, ChronoUnit.HOURS),
+                   now.minus(23, ChronoUnit.HOURS), now.minus(25, ChronoUnit.HOURS),
+                   now.minusSeconds(10), now.minus(1, ChronoUnit.MINUTES),
+                   Instant.EPOCH, now.minus(5, ChronoUnit.DAYS))
+                .entrySet().stream().map(entry -> {
+               final Instant modified = entry.getKey();
+               final Instant lastBackup = entry.getValue();
+
+               File file = new File();
+               file.setLabel("documentFile" + randomInt());
+               document.addFile(file);
+               file.setDocument(document);
+               file.setUri(Generator.generateUri());
+               file.setModified(modified);
+               file.setLastBackup(lastBackup);
+               return file;
+           }).toList();
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
@@ -29,6 +29,7 @@ import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.resource.Document;
 import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.model.resource.Resource;
+import cz.cvut.kbss.termit.rest.dto.ResourceSaveReason;
 import cz.cvut.kbss.termit.rest.handler.ErrorInfo;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.service.business.ResourceService;
@@ -191,7 +192,7 @@ class ResourceControllerTest extends BaseControllerTestRunner {
                                                                           return req;
                                                                       }))
                .andExpect(status().isNoContent());
-        verify(resourceServiceMock).saveContent(eq(file), any(InputStream.class));
+        verify(resourceServiceMock).saveContent(eq(file), any(InputStream.class), eq(ResourceSaveReason.UNKNOWN));
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/business/ResourceServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/ResourceServiceTest.java
@@ -36,7 +36,6 @@ import cz.cvut.kbss.termit.service.document.DocumentManager;
 import cz.cvut.kbss.termit.service.document.ResourceRetrievalSpecification;
 import cz.cvut.kbss.termit.service.document.TextAnalysisService;
 import cz.cvut.kbss.termit.service.document.backup.BackupReason;
-import cz.cvut.kbss.termit.service.document.backup.DocumentBackupManager;
 import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
 import cz.cvut.kbss.termit.util.Configuration;
@@ -184,7 +183,7 @@ class ResourceServiceTest {
     @Test
     void saveContentCreatesBackupBeforeSavingFileContentInDocumentManager() {
         final ResourceSaveReason saveReason = ResourceSaveReason.REUPLOAD;
-        final BackupReason backupReason = DocumentBackupManager.mapSaveReasonToBackup(saveReason).orElseThrow();
+        final BackupReason backupReason = saveReason.getBackupReason().orElseThrow();
         final ByteArrayInputStream bis = new ByteArrayInputStream("test".getBytes());
         final File file = Generator.generateFileWithId("test.html");
         when(documentManager.exists(file)).thenReturn(true);

--- a/src/test/java/cz/cvut/kbss/termit/service/document/AnnotationGeneratorTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/AnnotationGeneratorTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import java.io.BufferedReader;
@@ -79,6 +80,9 @@ class AnnotationGeneratorTest extends BaseServiceTestRunner {
 
     @Autowired
     private EntityManager em;
+
+    @MockitoBean
+    private DocumentManager documentManager;
 
     @Autowired
     private DescriptorFactory descriptorFactory;

--- a/src/test/java/cz/cvut/kbss/termit/service/document/BaseDocumentTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/BaseDocumentTestRunner.java
@@ -43,8 +43,12 @@ public abstract class BaseDocumentTestRunner extends BaseServiceTestRunner {
         configuration.getFile().setStorage(termitStorageDir.toString());
     }
 
-    protected java.io.File generateFile() throws Exception {
-        return generateFile("test", ".html", CONTENT);
+    protected java.io.File generateFile() {
+        try {
+            return generateFile("test", ".html", CONTENT);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected java.io.File generateFile(String filePrefix, String fileSuffix, String fileContent) throws Exception {

--- a/src/test/java/cz/cvut/kbss/termit/service/document/DefaultDocumentManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/DefaultDocumentManagerTest.java
@@ -149,8 +149,8 @@ class DefaultDocumentManagerTest extends BaseDocumentTestRunner {
         document.addFile(file);
         file.setDocument(document);
         sut.saveFileContent(file, content);
-        assertNotNull(file.getLastModified());
-        assertTrue(file.getLastModified().isAfter(before));
+        assertNotNull(file.getModified());
+        assertTrue(file.getModified().isAfter(before));
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
@@ -5,11 +5,13 @@ import cz.cvut.kbss.termit.exception.NotFoundException;
 import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.service.document.BaseDocumentTestRunner;
+import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
 import cz.cvut.kbss.termit.util.Utils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.nio.file.Files;
 import java.time.Instant;
@@ -30,9 +32,12 @@ public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
     private static final String BACKUP_REASON_VALUES_METHOD_SIGNATURE = "cz.cvut.kbss.termit.service.document.backup.BackupReason#values()";
     private DocumentBackupManager sut;
 
+    @MockitoBean
+    ResourceRepositoryService resourceRepositoryService;
+
     @BeforeEach
     void setupSut() {
-        sut = new DocumentBackupManager(configuration);
+        sut = new DocumentBackupManager(configuration, resourceRepositoryService);
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
@@ -27,6 +27,9 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
     private static final String BACKUP_REASON_VALUES_METHOD_SIGNATURE = "cz.cvut.kbss.termit.service.document.backup.BackupReason#values()";
@@ -38,6 +41,22 @@ public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
     @BeforeEach
     void setupSut() {
         sut = new DocumentBackupManager(configuration, resourceRepositoryService);
+    }
+
+    @Test
+    void createBackupUpdatesFileLastBackupTimestamp() {
+        Instant old = Instant.now().minusSeconds(10);
+        final File file = new File();
+        file.setModified(old);
+        file.setLastBackup(old);
+        final java.io.File physicalFile = generateFile();
+        file.setLabel(physicalFile.getName());
+        document.addFile(file);
+        file.setDocument(document);
+        sut.createBackup(file, BackupReason.UNKNOWN);
+        verify(resourceRepositoryService).update(eq(file));
+        assertEquals(old, file.getModified()); // no change expected
+        assertTrue(old.isBefore(file.getLastBackup()));
     }
 
     @Test

--- a/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentScheduledBackupManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentScheduledBackupManagerTest.java
@@ -1,0 +1,102 @@
+package cz.cvut.kbss.termit.service.document.backup;
+
+import cz.cvut.kbss.jopa.model.EntityManager;
+import cz.cvut.kbss.termit.environment.Generator;
+import cz.cvut.kbss.termit.model.resource.File;
+import cz.cvut.kbss.termit.service.document.BaseDocumentTestRunner;
+import cz.cvut.kbss.termit.util.Utils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class DocumentScheduledBackupManagerTest extends BaseDocumentTestRunner {
+    @Autowired
+    private DocumentScheduledBackupManager sut;
+
+    @Autowired
+    private EntityManager em;
+
+    @MockitoBean
+    private DocumentBackupManager backupManager;
+
+    private List<File> olderThan24Hours;
+    private List<File> modifiedIn24Hours;
+
+    private Instant now;
+    private Instant since;
+
+    @BeforeEach
+    public void generateFiles() {
+        now = Utils.timestamp();
+        since = now.minus(24, ChronoUnit.HOURS);
+
+        olderThan24Hours = new ArrayList<>();
+        modifiedIn24Hours = new ArrayList<>();
+
+        transactional(() -> em.persist(document));
+
+        // generate files with different modified timestamps
+        Stream.of(now.minus(25, ChronoUnit.HOURS),
+                now.minus(23, ChronoUnit.HOURS),
+                now.minusSeconds(10),
+                Instant.EPOCH)
+              .forEach(modified -> {
+
+            File file = generateDocumentFile();
+            file.setModified(modified);
+            transactional(() -> em.persist(file));
+
+            if (modified.isAfter(since)) {
+                modifiedIn24Hours.add(file);
+            } else {
+                olderThan24Hours.add(file);
+            }
+        });
+    }
+
+    private File generateDocumentFile() {
+        java.io.File physicalFile = generateFile();
+        File file = new File();
+        file.setLabel(physicalFile.getName());
+        document.addFile(file);
+        file.setDocument(document);
+        file.setUri(Generator.generateUri());
+        return file;
+    }
+
+    @Test
+    void findFilesModifiedSinceReturnsFilesSince24Hours() {
+        List<File> files = sut.findFilesModifiedSince(since);
+        assertEquals(modifiedIn24Hours.size(), files.size());
+        assertTrue(files.containsAll(modifiedIn24Hours));
+    }
+
+    @Test
+    void backupModifiedDocumentsBackupsDocumentsModifiedInLast24Hours() {
+        doNothing().when(backupManager).createBackup(any(), any());
+        sut.backupModifiedDocuments();
+        ArgumentCaptor<File> fileCaptor = ArgumentCaptor.forClass(File.class);
+        verify(backupManager, times(modifiedIn24Hours.size())).createBackup(fileCaptor.capture(), eq(BackupReason.SCHEDULED));
+        List<File> files = fileCaptor.getAllValues();
+        assertEquals(modifiedIn24Hours.size(), files.size());
+        assertTrue(files.containsAll(modifiedIn24Hours));
+    }
+}


### PR DESCRIPTION
- Resource controller now accepts an optional reason for saving the content of a file (defaults to `unknown`)
- File backup is now only created for file `reupload`, `new occurrence` or `remove occurrence` reasons
- Added `modified` and `last backup` timestamps to the document file entity
- Added a scheduled task at 03:00, which creates a backup for all files that were modified since the last backup
