### PR TITLE
[Enhancement kbss-cvut/termit-ui#679] Provide access to document backups

### DIFF
--- a/ontology/termit-glosář.ttl
+++ b/ontology/termit-glosář.ttl
@@ -698,3 +698,27 @@ termit-pojem:má-datum-a-čas-poslední-zálohy
                 termit:glosář ;
         <http://www.w3.org/2004/02/skos/core#prefLabel>
                 "Has date and time of the last backup"@en , "Má datum a čas poslední zálohy"@cs .
+
+termit-pojem:popis-zálohy-souboru
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+                <https://slovník.gov.cz/základní/pojem/typ-objektu> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+                termit:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+                "File backup description"@en , "Popis zálohy souboru"@cs ;
+        <http://www.w3.org/2004/02/skos/core#scopeNote>
+                "Describes a file backup created at a specific time for a specific reason."@en ,
+                "Popisuje zálohu souboru vytvořenou v určitém čase z určitého důvodu."@cs .
+
+termit-pojem:má-důvod-zálohy
+        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        <http://www.w3.org/2004/02/skos/core#broader>
+                <https://slovník.gov.cz/základní/pojem/vlastnost> , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
+        <http://www.w3.org/2004/02/skos/core#inScheme>
+                termit:glosář ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel>
+                "Has backup reason"@en , "Má důvod zálohy"@cs ;
+        <http://www.w3.org/2004/02/skos/core#scopeNote>
+                "Specifies the reason why a file backup was created."@en ,
+                "Určuje důvod, proč byla záloha souboru vytvořena."@cs .

--- a/ontology/termit-glosář.ttl
+++ b/ontology/termit-glosář.ttl
@@ -698,27 +698,3 @@ termit-pojem:má-datum-a-čas-poslední-zálohy
                 termit:glosář ;
         <http://www.w3.org/2004/02/skos/core#prefLabel>
                 "Has date and time of the last backup"@en , "Má datum a čas poslední zálohy"@cs .
-
-termit-pojem:popis-zálohy-souboru
-        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
-        <http://www.w3.org/2004/02/skos/core#broader>
-                <https://slovník.gov.cz/základní/pojem/typ-objektu> ;
-        <http://www.w3.org/2004/02/skos/core#inScheme>
-                termit:glosář ;
-        <http://www.w3.org/2004/02/skos/core#prefLabel>
-                "File backup description"@en , "Popis zálohy souboru"@cs ;
-        <http://www.w3.org/2004/02/skos/core#scopeNote>
-                "Describes a file backup created at a specific time for a specific reason."@en ,
-                "Popisuje zálohu souboru vytvořenou v určitém čase z určitého důvodu."@cs .
-
-termit-pojem:má-důvod-zálohy
-        a       <http://www.w3.org/2004/02/skos/core#Concept> ;
-        <http://www.w3.org/2004/02/skos/core#broader>
-                <https://slovník.gov.cz/základní/pojem/vlastnost> , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
-        <http://www.w3.org/2004/02/skos/core#inScheme>
-                termit:glosář ;
-        <http://www.w3.org/2004/02/skos/core#prefLabel>
-                "Has backup reason"@en , "Má důvod zálohy"@cs ;
-        <http://www.w3.org/2004/02/skos/core#scopeNote>
-                "Specifies the reason why a file backup was created."@en ,
-                "Určuje důvod, proč byla záloha souboru vytvořena."@cs .

--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -361,4 +361,11 @@ termit-pojem:má-datum-a-čas-poslední-zálohy
         rdfs:subPropertyOf  <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-datum-a-čas-modifikace> ;
         rdfs:range          xsd:dateTime .
 
+termit-pojem:popis-zálohy-souboru
+        a                <https://slovník.gov.cz/základní/pojem/typ-objektu>, owl:Class .
 
+termit-pojem:má-důvod-zálohy
+        a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
+        rdfs:domain         termit-pojem:popis-zálohy-souboru ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .

--- a/ontology/termit-model.ttl
+++ b/ontology/termit-model.ttl
@@ -360,12 +360,3 @@ termit-pojem:má-datum-a-čas-poslední-zálohy
         a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vztahu> ;
         rdfs:subPropertyOf  <http://onto.fel.cvut.cz/ontologies/slovník/agendový/popis-dat/pojem/má-datum-a-čas-modifikace> ;
         rdfs:range          xsd:dateTime .
-
-termit-pojem:popis-zálohy-souboru
-        a                <https://slovník.gov.cz/základní/pojem/typ-objektu>, owl:Class .
-
-termit-pojem:má-důvod-zálohy
-        a                   owl:DatatypeProperty , <https://slovník.gov.cz/základní/pojem/typ-vlastnosti> ;
-        rdfs:domain         termit-pojem:popis-zálohy-souboru ;
-        rdfs:range          rdfs:Literal ;
-        rdfs:subPropertyOf  <https://slovník.gov.cz/základní/pojem/vlastnost> .

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -389,6 +389,28 @@ public class ResourceController extends BaseController {
         return ResponseEntity.ok(dtos);
     }
 
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
+               description = "Restores backup from the given timestamp.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "Backup restoration started"),
+            @ApiResponse(responseCode = "404", description = "Resource not found.")
+    })
+    @PostMapping(value = "/{localName}/backups/restore")
+    public ResponseEntity<Void> restoreBackup(
+            @Parameter(description = ResourceControllerDoc.ID_LOCAL_NAME_DESCRIPTION,
+                       example = ResourceControllerDoc.ID_LOCAL_NAME_EXAMPLE)
+            @PathVariable String localName,
+            @Parameter(description = ResourceControllerDoc.ID_NAMESPACE_DESCRIPTION,
+                       example = ResourceControllerDoc.ID_NAMESPACE_EXAMPLE)
+            @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
+            @Parameter(description = "Timestamp of the backup to restore")
+            @RequestParam(name = "Backup timestamp") Instant backupTimestamp
+    ) {
+        final Resource resource = getResource(localName, namespace);
+        resourceService.restoreBackup(resource, backupTimestamp);
+        return ResponseEntity.accepted().build();
+    }
+
     /**
      * A couple of constants for the {@link ResourceController} API documentation.
      */

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -32,7 +32,6 @@ import cz.cvut.kbss.termit.security.SecurityConstants;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.service.business.ResourceService;
 import cz.cvut.kbss.termit.service.document.ResourceRetrievalSpecification;
-import cz.cvut.kbss.termit.service.document.backup.BackupFile;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Constants;
 import cz.cvut.kbss.termit.util.Constants.QueryParams;
@@ -68,7 +67,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -422,10 +420,9 @@ public class ResourceController extends BaseController {
         pageable = pageable.withPage(page);
 
         final List<FileBackupDto> dtos = resourceService.getBackupFiles(resource).stream()
-                .sorted(Comparator.comparing(BackupFile::timestamp).reversed())
                 .skip(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .map(FileBackupDto::new).toList();
+                .toList();
         return ResponseEntity.ok(dtos);
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -24,6 +24,7 @@ import cz.cvut.kbss.termit.model.TextAnalysisRecord;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.model.resource.Resource;
+import cz.cvut.kbss.termit.rest.dto.FileBackupDto;
 import cz.cvut.kbss.termit.rest.dto.ResourceSaveReason;
 import cz.cvut.kbss.termit.rest.util.RestUtils;
 import cz.cvut.kbss.termit.security.SecurityConstants;
@@ -366,6 +367,26 @@ public class ResourceController extends BaseController {
         final Resource resource = resourceService
                 .getReference(resolveIdentifier(resourceNamespace(namespace), localName));
         return resourceService.getChanges(resource, new ChangeRecordFilterDto());
+    }
+
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
+               description = "Gets all available backups for the resource.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Resource backups."),
+            @ApiResponse(responseCode = "404", description = "Resource not found.")
+    })
+    @GetMapping(value = "/{localName}/backups")
+    public ResponseEntity<List<FileBackupDto>> getBackups(
+            @Parameter(description = ResourceControllerDoc.ID_LOCAL_NAME_DESCRIPTION,
+                       example = ResourceControllerDoc.ID_LOCAL_NAME_EXAMPLE)
+            @PathVariable String localName,
+            @Parameter(description = ResourceControllerDoc.ID_NAMESPACE_DESCRIPTION,
+                       example = ResourceControllerDoc.ID_NAMESPACE_EXAMPLE)
+            @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace) {
+        final Resource resource = getResource(localName, namespace);
+        final List<FileBackupDto> dtos = resourceService.getBackupFiles(resource).stream()
+                .map(FileBackupDto::new).toList();
+        return ResponseEntity.ok(dtos);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/ResourceController.java
@@ -401,7 +401,7 @@ public class ResourceController extends BaseController {
             @ApiResponse(responseCode = "200", description = "Resource backups."),
             @ApiResponse(responseCode = "404", description = "Resource not found.")
     })
-    @GetMapping(value = "/{localName}/backups")
+    @GetMapping(value = "/{localName}/backups", produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
     public ResponseEntity<List<FileBackupDto>> getBackups(
             @Parameter(description = ResourceControllerDoc.ID_LOCAL_NAME_DESCRIPTION,
                        example = ResourceControllerDoc.ID_LOCAL_NAME_EXAMPLE)

--- a/src/main/java/cz/cvut/kbss/termit/rest/dto/FileBackupDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/dto/FileBackupDto.java
@@ -4,6 +4,7 @@ import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
 import cz.cvut.kbss.jopa.model.annotations.OWLClass;
 import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
 import cz.cvut.kbss.jopa.model.annotations.util.NonEntity;
+import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.termit.service.document.backup.BackupFile;
 import cz.cvut.kbss.termit.service.document.backup.BackupReason;
 import cz.cvut.kbss.termit.util.Vocabulary;
@@ -16,11 +17,11 @@ import java.util.Objects;
  * with a {@link #backupReason}
  */
 @NonEntity
-@OWLClass(iri = Vocabulary.s_c_popis_zalohy_souboru)
+@OWLClass(iri = Vocabulary.ONTOLOGY_IRI_TERMIT + "/popis-zálohy-souboru")
 public class FileBackupDto {
     @OWLAnnotationProperty(iri = Vocabulary.s_p_ma_datum_a_cas_vytvoreni)
     private Instant timestamp;
-    @OWLDataProperty(iri = Vocabulary.s_p_ma_duvod_zalohy)
+    @OWLDataProperty(iri = DC.Terms.DESCRIPTION)
     private BackupReason backupReason;
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/rest/dto/FileBackupDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/dto/FileBackupDto.java
@@ -1,0 +1,67 @@
+package cz.cvut.kbss.termit.rest.dto;
+
+import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.OWLDataProperty;
+import cz.cvut.kbss.jopa.model.annotations.util.NonEntity;
+import cz.cvut.kbss.termit.service.document.backup.BackupFile;
+import cz.cvut.kbss.termit.service.document.backup.BackupReason;
+import cz.cvut.kbss.termit.util.Vocabulary;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Dto used for description of a file backup created at {@link #timestamp}
+ * with a {@link #backupReason}
+ */
+@NonEntity
+@OWLClass(iri = Vocabulary.s_c_popis_zalohy_souboru)
+public final class FileBackupDto {
+    @OWLAnnotationProperty(iri = Vocabulary.s_p_ma_datum_a_cas_vytvoreni)
+    private final Instant timestamp;
+    @OWLDataProperty(iri = Vocabulary.s_p_ma_duvod_zalohy)
+    private final BackupReason backupReason;
+
+    /**
+     * @param timestamp    the timestamp at which the backup was created
+     * @param backupReason the reason of backup creation
+     */
+    public FileBackupDto(Instant timestamp, BackupReason backupReason) {
+        this.timestamp = timestamp;
+        this.backupReason = backupReason;
+    }
+
+    public FileBackupDto(BackupFile backupFile) {
+        this(backupFile.timestamp(), backupFile.backupReason());
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public BackupReason getBackupReason() {
+        return backupReason;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (FileBackupDto) obj;
+        return Objects.equals(this.timestamp, that.timestamp) &&
+                Objects.equals(this.backupReason, that.backupReason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, backupReason);
+    }
+
+    @Override
+    public String toString() {
+        return "FileBackupDto[" +
+                "timestamp=" + timestamp + ", " +
+                "backupReason=" + backupReason + ']';
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/rest/dto/FileBackupDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/dto/FileBackupDto.java
@@ -17,11 +17,11 @@ import java.util.Objects;
  */
 @NonEntity
 @OWLClass(iri = Vocabulary.s_c_popis_zalohy_souboru)
-public final class FileBackupDto {
+public class FileBackupDto {
     @OWLAnnotationProperty(iri = Vocabulary.s_p_ma_datum_a_cas_vytvoreni)
-    private final Instant timestamp;
+    private Instant timestamp;
     @OWLDataProperty(iri = Vocabulary.s_p_ma_duvod_zalohy)
-    private final BackupReason backupReason;
+    private BackupReason backupReason;
 
     /**
      * @param timestamp    the timestamp at which the backup was created
@@ -30,6 +30,10 @@ public final class FileBackupDto {
     public FileBackupDto(Instant timestamp, BackupReason backupReason) {
         this.timestamp = timestamp;
         this.backupReason = backupReason;
+    }
+
+    protected FileBackupDto() {
+        // default constructor and setters for deserialization
     }
 
     public FileBackupDto(BackupFile backupFile) {
@@ -42,6 +46,14 @@ public final class FileBackupDto {
 
     public BackupReason getBackupReason() {
         return backupReason;
+    }
+
+    protected void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    protected void setBackupReason(BackupReason backupReason) {
+        this.backupReason = backupReason;
     }
 
     @Override

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -425,7 +425,7 @@ public class ResourceService
      * @param backupTimestamp the timestamp of the desired backup to restore
      */
     @Transactional
-    @Throttle(value = "{#resource.getUri()}")
+    @Throttle(value = "{#resource.getUri()}", name = "restoreBackup")
     @PreAuthorize("@resourceAuthorizationService.canModify(#resource)")
     public void restoreBackup(Resource resource, Instant backupTimestamp) {
         Objects.requireNonNull(resource);

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -58,6 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -405,5 +406,22 @@ public class ResourceService
         verifyFileOperationPossible(asset, "Listing file backups");
         final File file = (File) asset;
         return documentBackupManager.getBackups(file, null);
+    }
+
+    /**
+     * Restores a backup for the given resource from the given timestamp.
+     * If no backup was created at the exact timestamp, the closest newest backup is restored.
+     *
+     * @param resource the resource for which the backup should be restored; must be a {@link File}
+     * @param backupTimestamp the timestamp of the desired backup to restore
+     */
+    @Transactional
+    public void restoreBackup(Resource resource, Instant backupTimestamp) {
+        Objects.requireNonNull(resource);
+        Objects.requireNonNull(backupTimestamp);
+        verifyFileOperationPossible(resource, "Restoring file backups");
+        final File file = (File) resource;
+        BackupFile backupFile = documentBackupManager.getBackup(file, backupTimestamp);
+        documentBackupManager.restoreBackup(file, backupFile);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -409,6 +409,7 @@ public class ResourceService
      * @param asset The file whose backups to list
      * @return the list of all backups
      */
+    @PreAuthorize("@resourceAuthorizationService.canModify(#asset)")
     public List<BackupFile> getBackupFiles(Resource asset) {
         verifyFileOperationPossible(asset, "Listing file backups");
         final File file = (File) asset;
@@ -424,6 +425,7 @@ public class ResourceService
      */
     @Transactional
     @Throttle(value = "{#resource.getUri()}")
+    @PreAuthorize("@resourceAuthorizationService.canModify(#resource)")
     public void restoreBackup(Resource resource, Instant backupTimestamp) {
         Objects.requireNonNull(resource);
         Objects.requireNonNull(backupTimestamp);

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -45,6 +45,7 @@ import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.TypeAwareResource;
+import cz.cvut.kbss.termit.util.throttle.Throttle;
 import jakarta.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -422,6 +423,7 @@ public class ResourceService
      * @param backupTimestamp the timestamp of the desired backup to restore
      */
     @Transactional
+    @Throttle(value = "{#resource.getUri()}")
     public void restoreBackup(Resource resource, Instant backupTimestamp) {
         Objects.requireNonNull(resource);
         Objects.requireNonNull(backupTimestamp);

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -37,6 +37,8 @@ import cz.cvut.kbss.termit.service.changetracking.ChangeRecordProvider;
 import cz.cvut.kbss.termit.service.document.DocumentManager;
 import cz.cvut.kbss.termit.service.document.ResourceRetrievalSpecification;
 import cz.cvut.kbss.termit.service.document.TextAnalysisService;
+import cz.cvut.kbss.termit.service.document.backup.BackupFile;
+import cz.cvut.kbss.termit.service.document.backup.DocumentBackupManager;
 import cz.cvut.kbss.termit.service.document.html.UnconfirmedTermOccurrenceRemover;
 import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.ResourceRepositoryService;
@@ -78,6 +80,8 @@ public class ResourceService
 
     private final DocumentManager documentManager;
 
+    private final DocumentBackupManager documentBackupManager;
+
     private final TextAnalysisService textAnalysisService;
 
     private final VocabularyService vocabularyService;
@@ -90,10 +94,12 @@ public class ResourceService
 
     @Autowired
     public ResourceService(ResourceRepositoryService repositoryService, DocumentManager documentManager,
+                           DocumentBackupManager documentBackupManager,
                            TextAnalysisService textAnalysisService, VocabularyService vocabularyService,
                            ChangeRecordService changeRecordService, Configuration config) {
         this.repositoryService = repositoryService;
         this.documentManager = documentManager;
+        this.documentBackupManager = documentBackupManager;
         this.textAnalysisService = textAnalysisService;
         this.vocabularyService = vocabularyService;
         this.changeRecordService = changeRecordService;
@@ -388,5 +394,16 @@ public class ResourceService
     @Override
     public void setApplicationEventPublisher(@Nonnull ApplicationEventPublisher eventPublisher) {
         this.eventPublisher = eventPublisher;
+    }
+
+    /**
+     * Lists all backups available for the specified {@code asset}.
+     * @param asset The file whose backups to list
+     * @return the list of all backups
+     */
+    public List<BackupFile> getBackupFiles(Resource asset) {
+        verifyFileOperationPossible(asset, "Listing file backups");
+        final File file = (File) asset;
+        return documentBackupManager.getBackups(file, null);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/ResourceService.java
@@ -431,6 +431,8 @@ public class ResourceService
         final File file = (File) resource;
         BackupFile backupFile = documentBackupManager.getBackup(file, backupTimestamp);
         final java.io.File physicalFile = documentBackupManager.restoreBackup(file, backupFile);
+        // dropping occurrences from database, otherwise they would be considered during annotation generation
+        repositoryService.removeOccurrencesTargeting(resource);
         try (FileInputStream fis = new FileInputStream(physicalFile)) {
             annotationGenerator.generateAnnotations(fis, file);
         } catch (Exception e) {

--- a/src/main/java/cz/cvut/kbss/termit/service/document/AnnotationGenerator.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/AnnotationGenerator.java
@@ -23,7 +23,6 @@ import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.assignment.TermOccurrence;
 import cz.cvut.kbss.termit.model.resource.File;
-import cz.cvut.kbss.termit.util.throttle.Throttle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,9 +67,9 @@ public class AnnotationGenerator {
      *
      * @param content Content of file with identified term occurrences
      * @param source  Source file of the annotated document
+     * @implNote Note that this operation might be time-consuming and so the caller should be running asynchronously.
      */
     @Transactional
-    @Throttle(value = "{source.getUri()}", name = "documentAnnotationGeneration")
     public void generateAnnotations(InputStream content, File source) {
         final TermOccurrenceResolver occurrenceResolver = findResolverFor(source);
         LOG.debug("Resolving annotations of file {}.", source);

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
@@ -265,6 +265,8 @@ public class DocumentBackupManager {
         // create backup if the file was modified since the last backup
         if (fileResource.getModified().isAfter(fileResource.getLastBackup())) {
             createBackup(fileResource, BackupReason.BACKUP_RESTORE);
+        } else {
+            LOG.debug("Skipping backup creation when restoring a backup, no changes have been made since the last backup of file {}", fileResource.getUri());
         }
 
         // resolve the physical file which will be replaced

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
@@ -210,7 +210,7 @@ public class DocumentBackupManager {
      */
     private BackupFile parseBackupFileName(java.io.File file) {
         if (!file.getName().contains(DocumentFileUtils.BACKUP_NAME_SEPARATOR)) {
-            return new BackupFile(Utils.timestamp(), file, BackupReason.UNKNOWN);
+            return null;
         }
         String strTimestamp = file.getName()
                                   .substring(file.getName().indexOf(DocumentFileUtils.BACKUP_NAME_SEPARATOR) + 1);

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
@@ -272,7 +272,7 @@ public class DocumentBackupManager {
         try {
             // restore the backup
             final java.io.File decompressedBackup = openBackup(backupFile);
-            Files.copy(decompressedBackup.toPath(), currentFile.toPath());
+            Files.copy(decompressedBackup.toPath(), currentFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             return currentFile;
         } catch (Exception e) {
             throw new BackupManagerException("Unable to restore backup.", e);

--- a/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManager.java
@@ -241,7 +241,7 @@ public class DocumentBackupManager {
 
         Collections.sort(backupTimestamps);
         for (Instant timestamp : backupTimestamps) {
-            if (timestamp.isAfter(at)) {
+            if (timestamp.equals(at) || timestamp.isAfter(at)) {
                 return backupMap.get(timestamp);
             }
         }
@@ -271,7 +271,7 @@ public class DocumentBackupManager {
 
         try {
             // restore the backup
-            final java.io.File decompressedBackup = decompressFile(backupFile.file());
+            final java.io.File decompressedBackup = openBackup(backupFile);
             Files.copy(decompressedBackup.toPath(), currentFile.toPath());
             return currentFile;
         } catch (Exception e) {

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/ResourceRepositoryService.java
@@ -132,4 +132,9 @@ public class ResourceRepositoryService extends BaseAssetRepositoryService<Resour
     public long getLastModified() {
         return resourceDao.getLastModified();
     }
+
+    @Transactional
+    public void removeOccurrencesTargeting(Resource target) {
+        termOccurrenceDao.removeAll(target);
+    }
 }

--- a/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
@@ -483,7 +483,7 @@ class ResourceControllerTest extends BaseControllerTestRunner {
     @Test
     void getBackupCountReturnsCountOfBackupsInHeader() throws Exception {
         final File file = generateFile();
-        final List<BackupFile> backups = generateEmptyBackups();
+        final List<FileBackupDto> backups = generateEmptyBackups().stream().map(FileBackupDto::new).toList();
         final int backupsCount = backups.size();
         when(resourceServiceMock.getBackupFiles(eq(file))).thenReturn(backups);
 
@@ -502,11 +502,12 @@ class ResourceControllerTest extends BaseControllerTestRunner {
     @Test
     void getBackupsReturnsPagedListOfBackupFiles() throws Exception {
         final File file = generateFile();
-        final List<BackupFile> backups = generateEmptyBackups();
-        backups.sort(Comparator.comparing(BackupFile::timestamp).reversed());
+        final List<FileBackupDto> backups = generateEmptyBackups().stream().map(FileBackupDto::new)
+                                                  .sorted(Comparator.comparing(FileBackupDto::getTimestamp).reversed())
+                                                  .toList();
         final int page = 5;
         final int pageSize = 1;
-        final FileBackupDto expectedDto = new FileBackupDto(backups.get(page));
+        final FileBackupDto expectedDto = backups.get(page);
 
         when(resourceServiceMock.getBackupFiles(eq(file))).thenReturn(backups);
 

--- a/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
@@ -29,16 +29,20 @@ import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.resource.Document;
 import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.model.resource.Resource;
+import cz.cvut.kbss.termit.rest.dto.FileBackupDto;
 import cz.cvut.kbss.termit.rest.dto.ResourceSaveReason;
 import cz.cvut.kbss.termit.rest.handler.ErrorInfo;
 import cz.cvut.kbss.termit.service.IdentifierResolver;
 import cz.cvut.kbss.termit.service.business.ResourceService;
 import cz.cvut.kbss.termit.service.document.ResourceRetrievalSpecification;
+import cz.cvut.kbss.termit.service.document.backup.BackupFile;
+import cz.cvut.kbss.termit.service.document.backup.BackupReason;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Constants;
 import cz.cvut.kbss.termit.util.Constants.QueryParams;
 import cz.cvut.kbss.termit.util.TypeAwareFileSystemResource;
 import cz.cvut.kbss.termit.util.Utils;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -462,5 +466,59 @@ class ResourceControllerTest extends BaseControllerTestRunner {
         assertEquals(HTML_CONTENT, resultContent);
         assertEquals(MediaType.TEXT_HTML_VALUE, mvcResult.getResponse().getHeader(HttpHeaders.CONTENT_TYPE));
         verify(resourceServiceMock).getContent(file, new ResourceRetrievalSpecification(Optional.empty(), true));
+    }
+
+    private List<BackupFile> generateEmptyBackups() {
+        final int backupsCount = 7;
+        final List<BackupFile> backups = new ArrayList<>(backupsCount);
+        for (int i = 0; i < backupsCount; i++) {
+            backups.add(new BackupFile(Instant.now(), null, BackupReason.UNKNOWN));
+        }
+        return backups;
+    }
+
+    @Test
+    void getBackupCountReturnsCountOfBackupsInHeader() throws Exception {
+        final File file = generateFile();
+        final List<BackupFile> backups = generateEmptyBackups();
+        final int backupsCount = backups.size();
+        when(resourceServiceMock.getBackupFiles(eq(file))).thenReturn(backups);
+
+        when(identifierResolverMock.resolveIdentifier(any(), eq(FILE_NAME)))
+                .thenReturn(file.getUri());
+        when(resourceServiceMock.findRequired(file.getUri())).thenReturn(file);
+
+        final HttpServletResponse response = mockMvc.perform(head(PATH + "/" + FILE_NAME + "/backups"))
+                                                     .andExpect(status().isOk()).andReturn().getResponse();
+
+        final String countHeader = response.getHeader(Constants.X_TOTAL_COUNT_HEADER);
+        assertNotNull(countHeader);
+        assertEquals(String.valueOf(backupsCount), countHeader);
+    }
+
+    @Test
+    void getBackupsReturnsPagedListOfBackupFiles() throws Exception {
+        final File file = generateFile();
+        final List<BackupFile> backups = generateEmptyBackups();
+        final int page = 5;
+        final int pageSize = 1;
+        final FileBackupDto expectedDto = new FileBackupDto(backups.get(page));
+
+        when(resourceServiceMock.getBackupFiles(eq(file))).thenReturn(backups);
+
+        when(identifierResolverMock.resolveIdentifier(any(), eq(FILE_NAME)))
+                .thenReturn(file.getUri());
+        when(resourceServiceMock.findRequired(file.getUri())).thenReturn(file);
+
+        final MvcResult mvcResult = mockMvc.perform(get(PATH + "/" + FILE_NAME + "/backups")
+                                                   .param("page", String.valueOf(page))
+                                                   .param("pageSize", String.valueOf(pageSize)))
+                                           .andExpect(status().isOk()).andReturn();
+
+        final List<FileBackupDto> result = readValue(mvcResult, new TypeReference<>() {
+        });
+
+        assertEquals(pageSize, result.size());
+        assertEquals(expectedDto,  result.get(0));
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/ResourceControllerTest.java
@@ -64,6 +64,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -470,9 +471,11 @@ class ResourceControllerTest extends BaseControllerTestRunner {
 
     private List<BackupFile> generateEmptyBackups() {
         final int backupsCount = 7;
+        Instant timestamp = Utils.timestamp();
         final List<BackupFile> backups = new ArrayList<>(backupsCount);
         for (int i = 0; i < backupsCount; i++) {
-            backups.add(new BackupFile(Instant.now(), null, BackupReason.UNKNOWN));
+            timestamp = timestamp.plusSeconds(10);
+            backups.add(new BackupFile(timestamp, null, BackupReason.UNKNOWN));
         }
         return backups;
     }
@@ -500,6 +503,7 @@ class ResourceControllerTest extends BaseControllerTestRunner {
     void getBackupsReturnsPagedListOfBackupFiles() throws Exception {
         final File file = generateFile();
         final List<BackupFile> backups = generateEmptyBackups();
+        backups.sort(Comparator.comparing(BackupFile::timestamp).reversed());
         final int page = 5;
         final int pageSize = 1;
         final FileBackupDto expectedDto = new FileBackupDto(backups.get(page));

--- a/src/test/java/cz/cvut/kbss/termit/service/document/BaseDocumentTestRunner.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/BaseDocumentTestRunner.java
@@ -65,7 +65,7 @@ public abstract class BaseDocumentTestRunner extends BaseServiceTestRunner {
     protected List<java.io.File> createTestBackups(File file, BackupReason reason) throws Exception {
         final List<java.io.File> backupFiles = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
-            Instant instant = Instant.ofEpochMilli(System.currentTimeMillis() - (i + 1) * 10000);
+            Instant instant = Instant.ofEpochMilli(System.currentTimeMillis() - (i + 1) * 1000000);
             final String newPath = DocumentFileUtils.generateBackupFileName(file, reason, instant) + ".bz2";
             final Path target = documentDir.resolve(newPath);
             Files.createFile(target);

--- a/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
@@ -421,4 +421,26 @@ public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
         final String result = String.join("\n", backupLines);
         assertEquals(CONTENT, result);
     }
+
+    @Test
+    void restoreBackupDoesNotCreateBackupIfTheFileWasNotModifiedSinceLastBackupRestoration() {
+        final File fileResource = new File();
+        final java.io.File originalFile = generateFile();
+        fileResource.setLabel(originalFile.getName());
+        document.addFile(fileResource);
+        fileResource.setDocument(document);
+        fileResource.setModified(Utils.timestamp());
+
+        sut.createBackup(fileResource, BackupReason.UNKNOWN);
+        assertNotNull(fileResource.getLastBackup());
+
+        assertTrue(fileResource.getModified().isBefore(fileResource.getLastBackup()));
+
+        BackupFile backupFile = sut.getBackup(fileResource, Instant.EPOCH);
+        assertNotNull(backupFile);
+
+        assertEquals(1, sut.getBackups(fileResource, null).size());
+        sut.restoreBackup(fileResource, backupFile);
+        assertEquals(1, sut.getBackups(fileResource, null).size());
+    }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
@@ -340,6 +340,31 @@ public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
     }
 
     @Test
+    void getBackupsReturnsBackupsSortedInDescendingOrder() throws Exception {
+        final File file = new File();
+        final java.io.File physicalFile = generateFile();
+        file.setLabel(physicalFile.getName());
+        document.addFile(file);
+        file.setDocument(document);
+        // generate backups for all reasons
+        for (BackupReason reason : BackupReason.values()) {
+            createTestBackups(file, reason);
+        }
+
+        List<BackupFile> backups = sut.getBackups(file, null);
+        assertTrue(backups.size() > 1);
+
+        BackupFile previous = backups.get(0);
+        for (int i = 1; i < backups.size(); i++) {
+            BackupFile current = backups.get(i);
+            // previous is equal or newer then the current one
+            assertFalse(previous.timestamp().isBefore(current.timestamp()));
+            previous = current;
+        }
+        assertTrue(backups.get(0).timestamp().isAfter(previous.timestamp()));
+    }
+
+    @Test
     void openBackupOpensCompressedBackup() throws Exception {
         final File file = new File();
         final java.io.File physicalFile = generateFile();

--- a/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/document/backup/DocumentBackupManagerTest.java
@@ -306,7 +306,7 @@ public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
         file.setLabel(physicalFile.getName());
         document.addFile(file);
         file.setDocument(document);
-        int expectedBackups = 1; // +1 for the original file
+        int expectedBackups = 0;
         // generate backups for all reasons
         for (BackupReason reason : BackupReason.values()) {
             createTestBackups(file, reason);
@@ -320,8 +320,7 @@ public class DocumentBackupManagerTest extends BaseDocumentTestRunner {
     @ParameterizedTest
     @MethodSource(BACKUP_REASON_VALUES_METHOD_SIGNATURE)
     void getBackupsReturnsOnlyBackupsWithGivenReason(BackupReason reasonFilter) throws Exception {
-        // add 1 for unknown reason for the original file
-        final int expectedBackups = 3 + (reasonFilter == BackupReason.UNKNOWN ? 1 : 0);
+        final int expectedBackups = 3;
         final File file = new File();
         final java.io.File physicalFile = generateFile();
         file.setLabel(physicalFile.getName());


### PR DESCRIPTION
Implements kbss-cvut/termit-ui#679

- Adds endpoints for listing backups, their count, and backup restoration
- Restoring a backup will create a new backup of the  current state if the file was modified since the last backup
- Restoring a backup will drop all term occurrences targeting the file and will generate them again based on the file contents
- Backups that do not use the backup name separator (`~`), which was introduced in 2023, will not be listed and cannot be restored