### PR TITLE
[Ref] Remove Bearer prefix from generated PAT

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/service/business/PersonalAccessTokenService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/PersonalAccessTokenService.java
@@ -7,7 +7,6 @@ import cz.cvut.kbss.termit.exception.TokenExpiredException;
 import cz.cvut.kbss.termit.model.PersonalAccessToken;
 import cz.cvut.kbss.termit.model.UserAccount;
 import cz.cvut.kbss.termit.security.JwtUtils;
-import cz.cvut.kbss.termit.security.SecurityConstants;
 import cz.cvut.kbss.termit.service.repository.PersonalAccessTokenRepositoryService;
 import cz.cvut.kbss.termit.service.security.SecurityUtils;
 import cz.cvut.kbss.termit.util.Utils;
@@ -72,7 +71,7 @@ public class PersonalAccessTokenService {
         newToken.setOwner(currentUser);
 
         repositoryService.persist(newToken);
-        return SecurityConstants.JWT_TOKEN_PREFIX + jwtUtils.generatePAT(newToken);
+        return jwtUtils.generatePAT(newToken);
     }
 
     /**

--- a/src/test/java/cz/cvut/kbss/termit/security/RestAuthenticationStackTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/security/RestAuthenticationStackTest.java
@@ -213,7 +213,7 @@ public class RestAuthenticationStackTest {
                 .andReturn();
         String patToken = result.getResponse().getContentAsString();
         assertFalse(Utils.isBlank(patToken));
-        return patToken;
+        return SecurityConstants.JWT_TOKEN_PREFIX + patToken;
     }
 
     private void mockExistingToken(Supplier<PersonalAccessToken> existingToken) {


### PR DESCRIPTION
Removes `Bearer` prefix from generated PAT tokens.