### PR TITLE
[Enhancement #418] Allow retrieving term with all ancestors

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/dto/FullTermDtoWithAncestors.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/FullTermDtoWithAncestors.java
@@ -14,35 +14,35 @@ import java.util.Set;
 /**
  * {@link Term} representation with blocked access to simple {@link #parentTerms parent} and {@link #externalParentTerms external parent}
  * terms.
- * Provides their extended representation allowing constructing full parent chain.
+ * Provides {@link #ancestorTerms} as a replacement for parent terms field.
  */
-public class FullTermDtoWithParents extends Term {
+public class FullTermDtoWithAncestors extends Term {
     /**
-     * Parent terms from the same vocabulary.
+     * Ancestors from the same vocabulary.
      */
     @JsonProperty("parentTerms")
     @OWLObjectProperty(iri = SKOS.BROADER, fetch = FetchType.EAGER, cascade = {CascadeType.DETACH})
-    private Set<TermInfoWithParents> fullParentTerms;
+    private Set<TermInfoWithParents> ancestorTerms;
 
     /**
      * Unsupported operation
      * @throws UnsupportedOperationException always
-     * @see #getFullParentTerms()
+     * @see #getAncestorTerms()
      */
     @JsonIgnore
     @Override
     public Set<TermInfo> getParentTerms() {
-        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors must not contain simple TermInfo parent terms");
     }
 
     /**
      * Unsupported operation
      * @throws UnsupportedOperationException always
-     * @see #setFullParentTerms(Set) ()
+     * @see #setAncestorTerms(Set) ()
      */
     @Override
     public void setParentTerms(Set<TermInfo> parentTerms) {
-        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors must not contain simple TermInfo parent terms");
     }
 
     /**
@@ -52,7 +52,7 @@ public class FullTermDtoWithParents extends Term {
     @JsonIgnore
     @Override
     public Set<TermInfo> getExternalParentTerms() {
-        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors must not contain simple TermInfo parent terms");
     }
 
     /**
@@ -61,7 +61,7 @@ public class FullTermDtoWithParents extends Term {
      */
     @Override
     public void setExternalParentTerms(Set<TermInfo> externalParentTerms) {
-        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors must not contain simple TermInfo parent terms");
     }
 
 
@@ -71,18 +71,18 @@ public class FullTermDtoWithParents extends Term {
      */
     @Override
     public void addParentTerm(Term term) {
-        throw new UnsupportedOperationException("FullTermDtoWithParents does not support adding individual parents");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors does not support adding individual parents");
     }
 
     /**
-     * Checks whether this term has a parent term in the same vocabulary.
+     * Checks whether this term has an ancestor in the same vocabulary.
      *
-     * @return Whether this term has a parent in its vocabulary. Returns {@code false} also if this term has no parent
-     * term at all.
+     * @return Whether this term has an ancestor in its vocabulary. Returns {@code false} also if this term has no ancestor
+     * at all.
      */
     @Override
     public boolean hasParentInSameVocabulary() {
-        return fullParentTerms != null && fullParentTerms.stream().anyMatch(p -> p.getVocabulary().equals(getVocabulary()));
+        return ancestorTerms != null && ancestorTerms.stream().anyMatch(p -> p.getVocabulary().equals(getVocabulary()));
     }
 
     /**
@@ -91,7 +91,7 @@ public class FullTermDtoWithParents extends Term {
      */
     @Override
     public void consolidateParents() {
-        throw new UnsupportedOperationException("FullTermDtoWithParents does not support parents consolidation");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors does not support parents consolidation");
     }
 
     /**
@@ -100,14 +100,14 @@ public class FullTermDtoWithParents extends Term {
      */
     @Override
     public void splitExternalAndInternalParents() {
-        throw new UnsupportedOperationException("FullTermDtoWithParents does not support parents consolidation");
+        throw new UnsupportedOperationException("FullTermDtoWithAncestors does not support parents consolidation");
     }
 
-    public Set<TermInfoWithParents> getFullParentTerms() {
-        return fullParentTerms;
+    public Set<TermInfoWithParents> getAncestorTerms() {
+        return ancestorTerms;
     }
 
-    public void setFullParentTerms(Set<TermInfoWithParents> fullParentTerms) {
-        this.fullParentTerms = fullParentTerms;
+    public void setAncestorTerms(Set<TermInfoWithParents> fullParentTerms) {
+        this.ancestorTerms = fullParentTerms;
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/FullTermDtoWithParents.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/FullTermDtoWithParents.java
@@ -1,0 +1,96 @@
+package cz.cvut.kbss.termit.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import cz.cvut.kbss.jopa.model.annotations.CascadeType;
+import cz.cvut.kbss.jopa.model.annotations.FetchType;
+import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
+import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
+
+import java.util.Set;
+
+public class FullTermDtoWithParents extends Term {
+    /**
+     * Parent terms from the same vocabulary.
+     */
+    @JsonProperty("parentTerms")
+    @OWLObjectProperty(iri = SKOS.BROADER, fetch = FetchType.EAGER, cascade = {CascadeType.DETACH})
+    private Set<TermInfoWithParents> fullParentTerms;
+
+    /**
+     * @see #getFullParentTerms()
+     */
+    @JsonIgnore
+    @Override
+    public Set<TermInfo> getParentTerms() {
+        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+    }
+
+    /**
+     * @see #setFullParentTerms(Set) ()
+     */
+    @Override
+    public void setParentTerms(Set<TermInfo> parentTerms) {
+        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+    }
+
+    @JsonIgnore
+    @Override
+    public Set<TermInfo> getExternalParentTerms() {
+        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+    }
+
+    @Override
+    public void setExternalParentTerms(Set<TermInfo> externalParentTerms) {
+        throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
+    }
+
+
+    /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void addParentTerm(Term term) {
+        throw new UnsupportedOperationException("FullTermDtoWithParents does not support adding individual parents");
+    }
+
+    /**
+     * Checks whether this term has a parent term in the same vocabulary.
+     *
+     * @return Whether this term has a parent in its vocabulary. Returns {@code false} also if this term has no parent
+     * term at all.
+     */
+    @Override
+    public boolean hasParentInSameVocabulary() {
+        return fullParentTerms != null && fullParentTerms.stream().anyMatch(p -> p.getVocabulary().equals(getVocabulary()));
+    }
+
+    /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void consolidateParents() {
+        throw new UnsupportedOperationException("FullTermDtoWithParents does not support parents consolidation");
+    }
+
+    /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public void splitExternalAndInternalParents() {
+        throw new UnsupportedOperationException("FullTermDtoWithParents does not support parents consolidation");
+    }
+
+    public Set<TermInfoWithParents> getFullParentTerms() {
+        return fullParentTerms;
+    }
+
+    public void setFullParentTerms(Set<TermInfoWithParents> fullParentTerms) {
+        this.fullParentTerms = fullParentTerms;
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/dto/FullTermDtoWithParents.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/FullTermDtoWithParents.java
@@ -11,6 +11,11 @@ import cz.cvut.kbss.termit.model.TermInfoWithParents;
 
 import java.util.Set;
 
+/**
+ * {@link Term} representation with blocked access to simple {@link #parentTerms parent} and {@link #externalParentTerms external parent}
+ * terms.
+ * Provides their extended representation allowing constructing full parent chain.
+ */
 public class FullTermDtoWithParents extends Term {
     /**
      * Parent terms from the same vocabulary.
@@ -20,6 +25,8 @@ public class FullTermDtoWithParents extends Term {
     private Set<TermInfoWithParents> fullParentTerms;
 
     /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
      * @see #getFullParentTerms()
      */
     @JsonIgnore
@@ -29,6 +36,8 @@ public class FullTermDtoWithParents extends Term {
     }
 
     /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
      * @see #setFullParentTerms(Set) ()
      */
     @Override
@@ -36,12 +45,20 @@ public class FullTermDtoWithParents extends Term {
         throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
     }
 
+    /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
+     */
     @JsonIgnore
     @Override
     public Set<TermInfo> getExternalParentTerms() {
         throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");
     }
 
+    /**
+     * Unsupported operation
+     * @throws UnsupportedOperationException always
+     */
     @Override
     public void setExternalParentTerms(Set<TermInfo> externalParentTerms) {
         throw new UnsupportedOperationException("FullTermDtoWithParents must not contain simple TermInfo parent terms");

--- a/src/main/java/cz/cvut/kbss/termit/dto/TermDescription.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/TermDescription.java
@@ -1,0 +1,17 @@
+package cz.cvut.kbss.termit.dto;
+
+import cz.cvut.kbss.jopa.model.MultilingualString;
+import cz.cvut.kbss.termit.model.util.HasIdentifier;
+import cz.cvut.kbss.termit.model.util.HasTypes;
+
+import java.io.Serializable;
+import java.net.URI;
+
+/**
+ * Object holding a basic description of a Term
+ */
+public interface TermDescription extends Serializable, HasIdentifier, HasTypes {
+    MultilingualString getLabel();
+    URI getVocabulary();
+    URI getState();
+}

--- a/src/main/java/cz/cvut/kbss/termit/dto/TermDescription.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/TermDescription.java
@@ -1,6 +1,7 @@
 package cz.cvut.kbss.termit.dto;
 
 import cz.cvut.kbss.jopa.model.MultilingualString;
+import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
 import cz.cvut.kbss.termit.model.util.HasIdentifier;
 import cz.cvut.kbss.termit.model.util.HasTypes;
 
@@ -10,6 +11,7 @@ import java.net.URI;
 /**
  * Object holding a basic description of a Term
  */
+@JsonLdAttributeOrder({"uri", "label", "vocabulary", "state"})
 public interface TermDescription extends Serializable, HasIdentifier, HasTypes {
     MultilingualString getLabel();
     URI getVocabulary();

--- a/src/main/java/cz/cvut/kbss/termit/dto/TermInfo.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/TermInfo.java
@@ -28,12 +28,9 @@ import cz.cvut.kbss.jopa.model.annotations.Types;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Term;
-import cz.cvut.kbss.termit.model.util.HasIdentifier;
-import cz.cvut.kbss.termit.model.util.HasTypes;
 import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.Vocabulary;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Objects;
@@ -45,7 +42,7 @@ import java.util.Set;
  * This is not a full-blown entity and should not be used to modify data.
  */
 @OWLClass(iri = SKOS.CONCEPT)
-public class TermInfo implements Serializable, HasIdentifier, HasTypes {
+public class TermInfo implements TermDescription {
 
     @Id
     private URI uri;
@@ -108,6 +105,7 @@ public class TermInfo implements Serializable, HasIdentifier, HasTypes {
         this.uri = uri;
     }
 
+    @Override
     public MultilingualString getLabel() {
         return label;
     }
@@ -116,6 +114,7 @@ public class TermInfo implements Serializable, HasIdentifier, HasTypes {
         this.label = label;
     }
 
+    @Override
     public URI getVocabulary() {
         return vocabulary;
     }
@@ -124,6 +123,7 @@ public class TermInfo implements Serializable, HasIdentifier, HasTypes {
         this.vocabulary = vocabulary;
     }
 
+    @Override
     public URI getState() {
         return state;
     }

--- a/src/main/java/cz/cvut/kbss/termit/dto/mapper/DtoMapper.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/mapper/DtoMapper.java
@@ -18,7 +18,7 @@
 package cz.cvut.kbss.termit.dto.mapper;
 
 import cz.cvut.kbss.jopa.model.MultilingualString;
-import cz.cvut.kbss.termit.dto.FullTermDtoWithParents;
+import cz.cvut.kbss.termit.dto.FullTermDtoWithAncestors;
 import cz.cvut.kbss.termit.dto.PasswordChangeRequestDto;
 import cz.cvut.kbss.termit.dto.PersonalAccessTokenDto;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
@@ -113,10 +113,10 @@ public abstract class DtoMapper {
     }
 
     /**
-     * Transforms normal term to {@link FullTermDtoWithParents}
+     * Transforms normal term to {@link FullTermDtoWithAncestors} and sets its ancestors
      */
-    @Mapping(source = "parents", target = "fullParentTerms")
+    @Mapping(source = "ancestors", target = "ancestorTerms")
     @Mapping(target = "parentTerms", ignore = true)
     @Mapping(target = "externalParentTerms", ignore = true)
-    public abstract FullTermDtoWithParents withFullParents(Term term, Set<TermInfoWithParents> parents);
+    public abstract FullTermDtoWithAncestors withAncestors(Term term, Set<TermInfoWithParents> ancestors);
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/mapper/DtoMapper.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/mapper/DtoMapper.java
@@ -18,6 +18,7 @@
 package cz.cvut.kbss.termit.dto.mapper;
 
 import cz.cvut.kbss.jopa.model.MultilingualString;
+import cz.cvut.kbss.termit.dto.FullTermDtoWithParents;
 import cz.cvut.kbss.termit.dto.PasswordChangeRequestDto;
 import cz.cvut.kbss.termit.dto.PersonalAccessTokenDto;
 import cz.cvut.kbss.termit.dto.acl.AccessControlListDto;
@@ -30,6 +31,7 @@ import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.PasswordChangeRequest;
 import cz.cvut.kbss.termit.model.PersonalAccessToken;
 import cz.cvut.kbss.termit.model.RdfsResource;
+import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.User;
 import cz.cvut.kbss.termit.model.UserGroup;
 import cz.cvut.kbss.termit.model.UserRole;
@@ -41,6 +43,7 @@ import cz.cvut.kbss.termit.model.util.EntityToOwlClassMapper;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Utils;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
@@ -107,4 +110,13 @@ public abstract class DtoMapper {
     public void setConfig(Configuration config) {
         this.config = config;
     }
+
+    /**
+     * Transforms normal term to {@link FullTermDtoWithParents}
+     * while removing all the parents allowing their population.
+     */
+    @Mapping(target = "fullParentTerms", ignore = true)
+    @Mapping(target = "parentTerms", ignore = true)
+    @Mapping(target = "externalParentTerms", ignore = true)
+    public abstract FullTermDtoWithParents withFullParents(Term term);
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/mapper/DtoMapper.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/mapper/DtoMapper.java
@@ -32,6 +32,7 @@ import cz.cvut.kbss.termit.model.PasswordChangeRequest;
 import cz.cvut.kbss.termit.model.PersonalAccessToken;
 import cz.cvut.kbss.termit.model.RdfsResource;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.User;
 import cz.cvut.kbss.termit.model.UserGroup;
 import cz.cvut.kbss.termit.model.UserRole;
@@ -113,10 +114,9 @@ public abstract class DtoMapper {
 
     /**
      * Transforms normal term to {@link FullTermDtoWithParents}
-     * while removing all the parents allowing their population.
      */
-    @Mapping(target = "fullParentTerms", ignore = true)
+    @Mapping(source = "parents", target = "fullParentTerms")
     @Mapping(target = "parentTerms", ignore = true)
     @Mapping(target = "externalParentTerms", ignore = true)
-    public abstract FullTermDtoWithParents withFullParents(Term term);
+    public abstract FullTermDtoWithParents withFullParents(Term term, Set<TermInfoWithParents> parents);
 }

--- a/src/main/java/cz/cvut/kbss/termit/dto/readonly/ReadOnlyTerm.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/readonly/ReadOnlyTerm.java
@@ -27,6 +27,7 @@ import cz.cvut.kbss.jopa.model.annotations.Properties;
 import cz.cvut.kbss.jopa.model.annotations.util.NonEntity;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import cz.cvut.kbss.termit.dto.TermDescription;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Term;
@@ -56,7 +57,7 @@ public class ReadOnlyTerm extends AbstractTerm {
     private Set<String> sources;
 
     @OWLObjectProperty(iri = SKOS.BROADER)
-    private Set<TermInfo> parentTerms;
+    private Set<TermDescription> parentTerms;
 
     @OWLDataProperty(iri = SKOS.NOTATION, simpleLiteral = true)
     private Set<String> notations;
@@ -157,11 +158,11 @@ public class ReadOnlyTerm extends AbstractTerm {
         this.sources = sources;
     }
 
-    public Set<TermInfo> getParentTerms() {
+    public Set<TermDescription> getParentTerms() {
         return parentTerms;
     }
 
-    public void setParentTerms(Set<TermInfo> parentTerms) {
+    public void setParentTerms(Set<TermDescription> parentTerms) {
         this.parentTerms = parentTerms;
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/model/AbstractTerm.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/AbstractTerm.java
@@ -29,16 +29,15 @@ import cz.cvut.kbss.jopa.model.annotations.Types;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
+import cz.cvut.kbss.termit.dto.TermDescription;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.model.util.AssetVisitor;
-import cz.cvut.kbss.termit.model.util.HasTypes;
 import cz.cvut.kbss.termit.model.util.SupportsSnapshots;
 import cz.cvut.kbss.termit.model.util.validation.HasPrimaryLanguage;
 import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.Vocabulary;
 import cz.cvut.kbss.termit.validation.PrimaryNotBlank;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -50,7 +49,7 @@ import java.util.stream.Collectors;
 @MappedSuperclass
 @JsonLdAttributeOrder({"uri", "label", "description", "subTerms"})
 public abstract class AbstractTerm extends Asset<MultilingualString>
-        implements HasTypes, SupportsSnapshots, HasPrimaryLanguage, Serializable {
+        implements SupportsSnapshots, HasPrimaryLanguage, TermDescription {
 
     @ParticipationConstraints(nonEmpty = true)
     @OWLAnnotationProperty(iri = SKOS.PREF_LABEL)
@@ -164,6 +163,7 @@ public abstract class AbstractTerm extends Asset<MultilingualString>
         this.subTerms = subTerms;
     }
 
+    @Override
     public URI getVocabulary() {
         return vocabulary;
     }
@@ -172,6 +172,7 @@ public abstract class AbstractTerm extends Asset<MultilingualString>
         this.vocabulary = vocabulary;
     }
 
+    @Override
     public URI getState() {
         return state;
     }

--- a/src/main/java/cz/cvut/kbss/termit/model/Term.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/Term.java
@@ -299,8 +299,8 @@ public class Term extends AbstractTerm implements SupportsSnapshots, HasTypes {
     /**
      * Adds the specified term to the parent terms of this instance.
      * <p>
-     * If the specified term is from the same glossary, it is added to {@code parentTerms}, otherwise, it is added to
-     * the {@code importedParentTerms}.
+     * If the specified term is from the same glossary, it is added to {@link parentTerms}, otherwise, it is added to
+     * the {@link externalParentTerms}.
      *
      * @param term Term to add as parent
      */

--- a/src/main/java/cz/cvut/kbss/termit/model/TermInfoWithParents.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/TermInfoWithParents.java
@@ -11,18 +11,16 @@ import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
 import cz.cvut.kbss.jopa.model.annotations.Types;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
-import cz.cvut.kbss.termit.model.util.HasIdentifier;
-import cz.cvut.kbss.termit.model.util.HasTypes;
+import cz.cvut.kbss.termit.dto.TermDescription;
 import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.Vocabulary;
 
-import java.io.Serializable;
 import java.net.URI;
 import java.util.Objects;
 import java.util.Set;
 
 @OWLClass(iri = SKOS.CONCEPT)
-public class TermInfoWithParents implements Serializable, HasIdentifier, HasTypes {
+public class TermInfoWithParents implements TermDescription {
 
     @Id
     private URI uri;
@@ -57,6 +55,7 @@ public class TermInfoWithParents implements Serializable, HasIdentifier, HasType
         this.uri = uri;
     }
 
+    @Override
     public MultilingualString getLabel() {
         return label;
     }
@@ -65,6 +64,7 @@ public class TermInfoWithParents implements Serializable, HasIdentifier, HasType
         this.label = label;
     }
 
+    @Override
     public URI getVocabulary() {
         return vocabulary;
     }
@@ -73,6 +73,7 @@ public class TermInfoWithParents implements Serializable, HasIdentifier, HasType
         this.vocabulary = vocabulary;
     }
 
+    @Override
     public URI getState() {
         return state;
     }

--- a/src/main/java/cz/cvut/kbss/termit/model/TermInfoWithParents.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/TermInfoWithParents.java
@@ -1,0 +1,122 @@
+package cz.cvut.kbss.termit.model;
+
+import cz.cvut.kbss.jopa.model.MultilingualString;
+import cz.cvut.kbss.jopa.model.annotations.CascadeType;
+import cz.cvut.kbss.jopa.model.annotations.FetchType;
+import cz.cvut.kbss.jopa.model.annotations.Id;
+import cz.cvut.kbss.jopa.model.annotations.Inferred;
+import cz.cvut.kbss.jopa.model.annotations.OWLAnnotationProperty;
+import cz.cvut.kbss.jopa.model.annotations.OWLClass;
+import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
+import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
+import cz.cvut.kbss.jopa.model.annotations.Types;
+import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import cz.cvut.kbss.termit.model.util.HasIdentifier;
+import cz.cvut.kbss.termit.model.util.HasTypes;
+import cz.cvut.kbss.termit.util.Utils;
+import cz.cvut.kbss.termit.util.Vocabulary;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Objects;
+import java.util.Set;
+
+@OWLClass(iri = SKOS.CONCEPT)
+public class TermInfoWithParents implements Serializable, HasIdentifier, HasTypes {
+
+    @Id
+    private URI uri;
+
+    @ParticipationConstraints(nonEmpty = true)
+    @OWLAnnotationProperty(iri = SKOS.PREF_LABEL)
+    private MultilingualString label;
+
+    @Inferred
+    @OWLObjectProperty(iri = SKOS.IN_SCHEME)
+    private URI vocabulary;
+
+    @OWLObjectProperty(iri = Vocabulary.s_p_has_state_of_term)
+    private URI state;
+
+    /**
+     * Parent terms from the same vocabulary.
+     */
+    @OWLObjectProperty(iri = SKOS.BROADER, fetch = FetchType.EAGER, cascade = {CascadeType.DETACH})
+    private Set<TermInfoWithParents> parentTerms;
+
+    @Types
+    private Set<String> types;
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    public MultilingualString getLabel() {
+        return label;
+    }
+
+    public void setLabel(MultilingualString label) {
+        this.label = label;
+    }
+
+    public URI getVocabulary() {
+        return vocabulary;
+    }
+
+    public void setVocabulary(URI vocabulary) {
+        this.vocabulary = vocabulary;
+    }
+
+    public URI getState() {
+        return state;
+    }
+
+    public void setState(URI state) {
+        this.state = state;
+    }
+
+    public Set<TermInfoWithParents> getParentTerms() {
+        return parentTerms;
+    }
+
+    public void setParentTerms(Set<TermInfoWithParents> parentTerms) {
+        this.parentTerms = parentTerms;
+    }
+
+    @Override
+    public Set<String> getTypes() {
+        return types;
+    }
+
+    @Override
+    public void setTypes(Set<String> types) {
+        this.types = types;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TermInfoWithParents termInfoWithParents)) {
+            return false;
+        }
+        return Objects.equals(uri, termInfoWithParents.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri);
+    }
+
+    @Override
+    public String toString() {
+        return "TermInfoWithParents{" + label + " " + Utils.uriToString(uri) + '}';
+    }
+}

--- a/src/main/java/cz/cvut/kbss/termit/model/TermInfoWithParents.java
+++ b/src/main/java/cz/cvut/kbss/termit/model/TermInfoWithParents.java
@@ -11,6 +11,7 @@ import cz.cvut.kbss.jopa.model.annotations.OWLObjectProperty;
 import cz.cvut.kbss.jopa.model.annotations.ParticipationConstraints;
 import cz.cvut.kbss.jopa.model.annotations.Types;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
+import cz.cvut.kbss.jsonld.annotation.JsonLdAttributeOrder;
 import cz.cvut.kbss.termit.dto.TermDescription;
 import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.Vocabulary;
@@ -20,6 +21,7 @@ import java.util.Objects;
 import java.util.Set;
 
 @OWLClass(iri = SKOS.CONCEPT)
+@JsonLdAttributeOrder({"uri", "label", "vocabulary", "state", "parentTerms"})
 public class TermInfoWithParents implements TermDescription {
 
     @Id

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -1207,12 +1207,12 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
     }
 
     /**
-     * Finds terms by the specified identifiers including their full parent chain.
+     * Finds terms by the specified identifiers including their full ancestor chain.
      *
      * @param termUris terms to fetch
-     * @return the requested terms with full parent chain
+     * @return the requested terms with full ancestor chain
      */
-    public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
+    public Set<TermInfoWithParents> findWithAllAncestors(Set<URI> termUris) {
         Objects.requireNonNull(termUris, "Term URIs cannot be null");
         if (termUris.isEmpty()) {
             return Set.of();

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -1212,7 +1212,11 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
      * @param termUris terms to fetch
      * @return the requested terms with full parent chain
      */
-    public Set<cz.cvut.kbss.termit.model.TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
+    public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
+        Objects.requireNonNull(termUris, "Term URIs cannot be null");
+        if (termUris.isEmpty()) {
+            return Set.of();
+        }
         try {
             return em.createQuery("SELECT DISTINCT t FROM Term t WHERE t.uri IN :termUris", TermInfoWithParents.class)
                      .setParameter("termUris", termUris)

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -38,6 +38,7 @@ import cz.cvut.kbss.termit.event.VocabularyContentModifiedEvent;
 import cz.cvut.kbss.termit.exception.PersistenceException;
 import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.util.HasIdentifier;
 import cz.cvut.kbss.termit.persistence.context.DescriptorFactory;
@@ -1203,5 +1204,21 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
             subTermsCache.evict(evt.getTermUri());
         }
         // related, relatedMatch and exactMatch inverse are loaded separately and not cached
+    }
+
+    /**
+     * Finds terms by the specified identifiers including their full parent chain.
+     *
+     * @param termUris terms to fetch
+     * @return the requested terms with full parent chain
+     */
+    public Set<cz.cvut.kbss.termit.model.TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
+        try {
+            return em.createQuery("SELECT DISTINCT t FROM Term t WHERE t.uri IN :termUris", TermInfoWithParents.class)
+                     .setParameter("termUris", termUris)
+                     .getResultStream().collect(Collectors.toSet());
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -346,8 +346,8 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
-            @Parameter(description = ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
-            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
+            @Parameter(description = ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
+            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
         return getById(termUri, populateCustomAttributes, loadAllParents);
     }
@@ -369,18 +369,18 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
-            @Parameter(description = ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
-            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
+            @Parameter(description = ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
+            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
         return getById(termUri, populateCustomAttributes, loadAllParents);
     }
 
-    private Term getById(URI termUri, boolean populateCustomAttributes, boolean loadAllParents) {
+    private Term getById(URI termUri, boolean populateCustomAttributes, boolean withAncestors) {
         final Term term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
                 termService.findRequired(termUri);
 
-        if (loadAllParents) {
-            return termService.resolveAllParents(term);
+        if (withAncestors) {
+            return termService.resolveAllAncestors(term);
         }
         return term;
     }
@@ -1053,7 +1053,7 @@ public class TermController extends BaseController {
         public static final String ID_STANDALONE_NAMESPACE_EXAMPLE = "http://onto.fel.cvut.cz/ontologies/slovnik/datovy-mpp-3.4/pojem/";
         public static final String ID_STANDALONE_NOT_FOUND_DESCRIPTION = "Term with the specified identifier not found.";
         public static final String ID_POPULATE_CUSTOM_ATTS_DESCRIPTION = "Whether to populate custom attribute values that reference terms with actual terms (instead of just their URI)";
-        public static final String ID_LOAD_ALL_PARENTS_DESCRIPTION = "Whether to load all parent terms for the term";
+        public static final String ID_WITH_ANCESTORS_DESCRIPTION = "Whether to load all ancestors for the term";
 
         private ApiDoc() {
             throw new AssertionError();

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -347,9 +347,9 @@ public class TermController extends BaseController {
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
             @Parameter(description = ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
-            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
+            @RequestParam(name = "withAncestors", required = false) boolean withAncestors) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        return getById(termUri, populateCustomAttributes, loadAllParents);
+        return getById(termUri, populateCustomAttributes, withAncestors);
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -370,9 +370,9 @@ public class TermController extends BaseController {
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
             @Parameter(description = ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
-            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
+            @RequestParam(name = "withAncestors", required = false) boolean withAncestors) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
-        return getById(termUri, populateCustomAttributes, loadAllParents);
+        return getById(termUri, populateCustomAttributes, withAncestors);
     }
 
     private Term getById(URI termUri, boolean populateCustomAttributes, boolean withAncestors) {

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -349,13 +349,7 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
             @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        final Term term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
-               termService.findRequired(termUri);
-
-        if (loadAllParents) {
-            return termService.resolveAllParents(term);
-        }
-        return term;
+        return getById(termUri, populateCustomAttributes, loadAllParents);
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -378,8 +372,12 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
             @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
+        return getById(termUri, populateCustomAttributes, loadAllParents);
+    }
+
+    private Term getById(URI termUri, boolean populateCustomAttributes, boolean loadAllParents) {
         final Term term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
-               termService.findRequired(termUri);
+                termService.findRequired(termUri);
 
         if (loadAllParents) {
             return termService.resolveAllParents(term);

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -345,10 +345,17 @@ public class TermController extends BaseController {
             @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
             @Parameter(description = ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
-                          required = false) boolean populateCustomAttributes) {
+                          required = false) boolean populateCustomAttributes,
+            @Parameter(description = ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
+            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        return populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
+        final Term term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
                termService.findRequired(termUri);
+
+        if (loadAllParents) {
+            return termService.resolveAllParents(term);
+        }
+        return term;
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -481,7 +488,7 @@ public class TermController extends BaseController {
             @PathVariable String termLocalName,
             @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
             @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace) {
-        final Term parent = getById(localName, termLocalName, namespace, false);
+        final Term parent = getById(localName, termLocalName, namespace, false, false);
         return termService.findSubTerms(parent);
     }
 
@@ -525,7 +532,7 @@ public class TermController extends BaseController {
             @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
             @Parameter(description = "The new term.")
             @RequestBody Term newTerm) {
-        final Term parent = getById(localName, termLocalName, namespace, false);
+        final Term parent = getById(localName, termLocalName, namespace, false, false);
         termService.persistChild(newTerm, parent);
         LOG.debug("Child term {} of parent {} created.", newTerm, parent);
         return ResponseEntity.created(createSubTermLocation(newTerm.getUri(), termLocalName)).build();
@@ -663,7 +670,7 @@ public class TermController extends BaseController {
         LOG.warn(
                 "Called legacy endpoint intended for internal use or testing only! (/vocabularies/{}/terms/{}/text-analysis)",
                 localName, termLocalName);
-        termService.analyzeTermDefinition(getById(localName, termLocalName, namespace, false),
+        termService.analyzeTermDefinition(getById(localName, termLocalName, namespace, false, false),
                                           getVocabularyUri(namespace, localName));
     }
 
@@ -1041,6 +1048,9 @@ public class TermController extends BaseController {
         public static final String ID_STANDALONE_NAMESPACE_EXAMPLE = "http://onto.fel.cvut.cz/ontologies/slovnik/datovy-mpp-3.4/pojem/";
         public static final String ID_STANDALONE_NOT_FOUND_DESCRIPTION = "Term with the specified identifier not found.";
         public static final String ID_POPULATE_CUSTOM_ATTS_DESCRIPTION = "Whether to populate custom attribute values that reference terms with actual terms (instead of just their URI)";
+
+        public static final String ID_LOAD_ALL_PARENTS_NAME = "loadAllParents";
+        public static final String ID_LOAD_ALL_PARENTS_DESCRIPTION = "Whether to load all parent terms for the term";
 
         private ApiDoc() {
             throw new AssertionError();

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -374,10 +374,17 @@ public class TermController extends BaseController {
             @RequestParam(name = QueryParams.NAMESPACE) String namespace,
             @Parameter(description = ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
-                          required = false) boolean populateCustomAttributes) {
+                          required = false) boolean populateCustomAttributes,
+            @Parameter(description = ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
+            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
-        return populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
+        final Term term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
                termService.findRequired(termUri);
+
+        if (loadAllParents) {
+            return termService.resolveAllParents(term);
+        }
+        return term;
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -510,7 +517,7 @@ public class TermController extends BaseController {
             @Parameter(description = ApiDoc.ID_STANDALONE_NAMESPACE_DESCRIPTION,
                        example = ApiDoc.ID_STANDALONE_NAMESPACE_EXAMPLE)
             @RequestParam(name = QueryParams.NAMESPACE) String namespace) {
-        final Term parent = getById(localName, namespace, false);
+        final Term parent = getById(localName, namespace, false, false);
         return termService.findSubTerms(parent);
     }
 
@@ -560,7 +567,7 @@ public class TermController extends BaseController {
                        example = ApiDoc.ID_STANDALONE_NAMESPACE_EXAMPLE)
             @RequestParam(name = QueryParams.NAMESPACE) String namespace,
             @RequestBody Term newTerm) {
-        final Term parent = getById(localName, namespace, false);
+        final Term parent = getById(localName, namespace, false, false);
         termService.persistChild(newTerm, parent);
         LOG.debug("Child term {} of parent {} created.", newTerm, parent);
         return ResponseEntity.created(createSubTermLocation(newTerm.getUri(), localName)).build();
@@ -1048,8 +1055,6 @@ public class TermController extends BaseController {
         public static final String ID_STANDALONE_NAMESPACE_EXAMPLE = "http://onto.fel.cvut.cz/ontologies/slovnik/datovy-mpp-3.4/pojem/";
         public static final String ID_STANDALONE_NOT_FOUND_DESCRIPTION = "Term with the specified identifier not found.";
         public static final String ID_POPULATE_CUSTOM_ATTS_DESCRIPTION = "Whether to populate custom attribute values that reference terms with actual terms (instead of just their URI)";
-
-        public static final String ID_LOAD_ALL_PARENTS_NAME = "loadAllParents";
         public static final String ID_LOAD_ALL_PARENTS_DESCRIPTION = "Whether to load all parent terms for the term";
 
         private ApiDoc() {

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -167,10 +167,18 @@ public class ReadOnlyTermController extends BaseController {
             @RequestParam(name = Constants.QueryParams.NAMESPACE, required = false) Optional<String> namespace,
             @Parameter(description = TermController.ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
-                          required = false) boolean populateCustomAttributes) {
+                          required = false) boolean populateCustomAttributes,
+            @Parameter(description = TermController.ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
+            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        return populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
+        final ReadOnlyTerm term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
                termService.findRequired(termUri);
+
+        if (loadAllParents) {
+            termService.resolveAllParents(term);
+        }
+
+        return term;
     }
 
     private URI getTermUri(String vocabIdFragment, String termIdFragment, Optional<String> namespace) {
@@ -194,10 +202,18 @@ public class ReadOnlyTermController extends BaseController {
             @RequestParam(name = Constants.QueryParams.NAMESPACE) String namespace,
             @Parameter(description = TermController.ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
-                          required = false) boolean populateCustomAttributes) {
+                          required = false) boolean populateCustomAttributes,
+            @Parameter(description = TermController.ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
+            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
-        return populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
+        final ReadOnlyTerm term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
                termService.findRequired(termUri);
+
+        if (loadAllParents) {
+            termService.resolveAllParents(term);
+        }
+
+        return term;
     }
 
     @Operation(security = {@SecurityRequirement(name = "bearer-key")},
@@ -235,7 +251,7 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = TermController.ApiDoc.ID_NAMESPACE_DESCRIPTION,
                        example = TermController.ApiDoc.ID_NAMESPACE_EXAMPLE)
             @RequestParam(name = Constants.QueryParams.NAMESPACE, required = false) Optional<String> namespace) {
-        final ReadOnlyTerm parent = getById(localName, termLocalName, namespace, false);
+        final ReadOnlyTerm parent = getById(localName, termLocalName, namespace, false, false);
         return termService.findSubTerms(parent);
     }
 
@@ -253,7 +269,7 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = TermController.ApiDoc.ID_STANDALONE_NAMESPACE_DESCRIPTION,
                        example = TermController.ApiDoc.ID_STANDALONE_NAMESPACE_EXAMPLE)
             @RequestParam(name = Constants.QueryParams.NAMESPACE) String namespace) {
-        final ReadOnlyTerm parent = getById(localName, namespace, false);
+        final ReadOnlyTerm parent = getById(localName, namespace, false, false);
         return termService.findSubTerms(parent);
     }
 
@@ -381,7 +397,7 @@ public class ReadOnlyTermController extends BaseController {
                                                   description = "Timestamp (ISO-formatted) at which the returned version was valid.",
                                                   example = ApiDocConstants.DATETIME_EXAMPLE)
                                           @RequestParam(name = "at", required = false) Optional<String> at) {
-        final ReadOnlyTerm term = getById(localName, termLocalName, namespace, false);
+        final ReadOnlyTerm term = getById(localName, termLocalName, namespace, false, false);
         return getTermSnapshots(at, term);
     }
 
@@ -412,7 +428,7 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = "Timestamp (ISO-formatted) at which the returned version was valid.",
                        example = ApiDocConstants.DATETIME_EXAMPLE)
             @RequestParam(name = "at", required = false) Optional<String> at) {
-        final ReadOnlyTerm term = getById(localName, namespace, false);
+        final ReadOnlyTerm term = getById(localName, namespace, false, false);
         return getTermSnapshots(at, term);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -171,13 +171,7 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = TermController.ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
             @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        final ReadOnlyTerm term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
-               termService.findRequired(termUri);
-
-        if (loadAllParents) {
-            termService.resolveAllParents(term);
-        }
-        return term;
+        return getById(termUri, populateCustomAttributes, loadAllParents);
     }
 
     private URI getTermUri(String vocabIdFragment, String termIdFragment, Optional<String> namespace) {
@@ -205,8 +199,12 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = TermController.ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
             @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
+        return getById(termUri, populateCustomAttributes, loadAllParents);
+    }
+
+    private ReadOnlyTerm getById(URI termUri, boolean populateCustomAttributes, boolean loadAllParents) {
         final ReadOnlyTerm term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
-               termService.findRequired(termUri);
+                termService.findRequired(termUri);
 
         if (loadAllParents) {
             termService.resolveAllParents(term);

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -168,8 +168,8 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = TermController.ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
-            @Parameter(description = TermController.ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
-            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
+            @Parameter(description = TermController.ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
+            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
         return getById(termUri, populateCustomAttributes, loadAllParents);
     }
@@ -196,8 +196,8 @@ public class ReadOnlyTermController extends BaseController {
             @Parameter(description = TermController.ApiDoc.ID_POPULATE_CUSTOM_ATTS_DESCRIPTION)
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
-            @Parameter(description = TermController.ApiDoc.ID_LOAD_ALL_PARENTS_DESCRIPTION)
-            @RequestParam(name = "loadAllParents", required = false) boolean loadAllParents) {
+            @Parameter(description = TermController.ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
+            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
         return getById(termUri, populateCustomAttributes, loadAllParents);
     }
@@ -207,7 +207,7 @@ public class ReadOnlyTermController extends BaseController {
                 termService.findRequired(termUri);
 
         if (loadAllParents) {
-            termService.resolveAllParents(term);
+            termService.resolveAllAncestors(term);
         }
         return term;
     }

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -177,7 +177,6 @@ public class ReadOnlyTermController extends BaseController {
         if (loadAllParents) {
             termService.resolveAllParents(term);
         }
-
         return term;
     }
 
@@ -212,7 +211,6 @@ public class ReadOnlyTermController extends BaseController {
         if (loadAllParents) {
             termService.resolveAllParents(term);
         }
-
         return term;
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -169,9 +169,9 @@ public class ReadOnlyTermController extends BaseController {
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
             @Parameter(description = TermController.ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
-            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
+            @RequestParam(name = "withAncestors", required = false) boolean withAncestors) {
         final URI termUri = getTermUri(localName, termLocalName, namespace);
-        return getById(termUri, populateCustomAttributes, loadAllParents);
+        return getById(termUri, populateCustomAttributes, withAncestors);
     }
 
     private URI getTermUri(String vocabIdFragment, String termIdFragment, Optional<String> namespace) {
@@ -197,16 +197,16 @@ public class ReadOnlyTermController extends BaseController {
             @RequestParam(name = "populateCustomAttributeTermReferences",
                           required = false) boolean populateCustomAttributes,
             @Parameter(description = TermController.ApiDoc.ID_WITH_ANCESTORS_DESCRIPTION)
-            @RequestParam(name = "withAncestors", required = false) boolean loadAllParents) {
+            @RequestParam(name = "withAncestors", required = false) boolean withAncestors) {
         final URI termUri = idResolver.resolveIdentifier(namespace, localName);
-        return getById(termUri, populateCustomAttributes, loadAllParents);
+        return getById(termUri, populateCustomAttributes, withAncestors);
     }
 
-    private ReadOnlyTerm getById(URI termUri, boolean populateCustomAttributes, boolean loadAllParents) {
+    private ReadOnlyTerm getById(URI termUri, boolean populateCustomAttributes, boolean withAncestors) {
         final ReadOnlyTerm term = populateCustomAttributes ? termService.findRequiredWithPopulatedCustomAttributes(termUri) :
                 termService.findRequired(termUri);
 
-        if (loadAllParents) {
+        if (withAncestors) {
             termService.resolveAllAncestors(term);
         }
         return term;

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -403,9 +403,9 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
     }
 
     /**
-     * Resolves the full ancestors chain of the {@code term}.
+     * Resolves the full ancestor chain of the {@code term}.
      *
-     * @param term term for which the full ancestors chain should be resolved
+     * @param term term for which the full ancestor chain should be resolved
      * @return {@link FullTermDtoWithAncestors} with {@link FullTermDtoWithAncestors#getAncestorTerms() ancestorTerms} set
      */
     @PreAuthorize("@termAuthorizationService.canRead(#term)")

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -399,6 +399,12 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         return result;
     }
 
+    /**
+     * Resolves the full parent chain of the {@code term}.
+     *
+     * @param term term for which the full parent chain should be resolved
+     * @return {@link FullTermDtoWithParents} with {@link FullTermDtoWithParents#getFullParentTerms() fullParentTerms} set
+     */
     @PreAuthorize("@termAuthorizationService.canRead(#term)")
     public FullTermDtoWithParents resolveAllParents(Term term) {
         if (term.getParentTerms() == null) {
@@ -412,6 +418,13 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         return dtoMapper.withFullParents(term, fullParents);
     }
 
+    /**
+     * Finds all terms using their URIs including all their parents.
+     *
+     * @param termUris term identifiers to find
+     * @return requested terms with their full parent chain
+     * @throws PersistenceException if any of the requested terms could not be found
+     */
     @PostAuthorize("@termAuthorizationService.canRead(returnObject.stream())")
     public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
         Set<TermInfoWithParents> fullTerms =

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -401,6 +401,9 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
 
     @PreAuthorize("@termAuthorizationService.canRead(#term)")
     public FullTermDtoWithParents resolveAllParents(Term term) {
+        if (term.getParentTerms() == null) {
+            return dtoMapper.withFullParents(term, Set.of());
+        }
         final Set<URI> directParentIdentifiers = term.getParentTerms()
                 .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
 
@@ -409,6 +412,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         return dtoMapper.withFullParents(term, fullParents);
     }
 
+    @PostAuthorize("@termAuthorizationService.canRead(returnObject.stream())")
     public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
         Set<TermInfoWithParents> fullTerms =
                 Collections.unmodifiableSet(repositoryService.findWithAllParents(termUris));

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -17,7 +17,7 @@
  */
 package cz.cvut.kbss.termit.service.business;
 
-import cz.cvut.kbss.termit.dto.FullTermDtoWithParents;
+import cz.cvut.kbss.termit.dto.FullTermDtoWithAncestors;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermOccurrences;
@@ -48,6 +48,7 @@ import cz.cvut.kbss.termit.service.export.VocabularyExporters;
 import cz.cvut.kbss.termit.service.language.LanguageService;
 import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.TermRepositoryService;
+import cz.cvut.kbss.termit.service.security.authorization.TermAuthorizationService;
 import cz.cvut.kbss.termit.util.TypeAwareResource;
 import cz.cvut.kbss.termit.util.Utils;
 import cz.cvut.kbss.termit.util.throttle.Throttle;
@@ -65,7 +66,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -101,13 +101,15 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
 
     private final LanguageService languageService;
     private final DtoMapper dtoMapper;
+    private final TermAuthorizationService termAuthorizationService;
 
     @Autowired
     public TermService(VocabularyExporters exporters, VocabularyService vocabularyService,
                        VocabularyContextMapper vocabularyContextMapper,
                        TermRepositoryService repositoryService, TextAnalysisService textAnalysisService,
                        TermOccurrenceService termOccurrenceService, ChangeRecordService changeRecordService,
-                       CommentService commentService, LanguageService languageService, DtoMapper dtoMapper) {
+                       CommentService commentService, LanguageService languageService, DtoMapper dtoMapper,
+                       TermAuthorizationService termAuthorizationService) {
         this.exporters = exporters;
         this.vocabularyService = vocabularyService;
         this.vocabularyContextMapper = vocabularyContextMapper;
@@ -118,6 +120,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         this.commentService = commentService;
         this.languageService = languageService;
         this.dtoMapper = dtoMapper;
+        this.termAuthorizationService = termAuthorizationService;
     }
 
     /**
@@ -403,40 +406,43 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      * Resolves the full parent chain of the {@code term}.
      *
      * @param term term for which the full parent chain should be resolved
-     * @return {@link FullTermDtoWithParents} with {@link FullTermDtoWithParents#getFullParentTerms() fullParentTerms} set
+     * @return {@link FullTermDtoWithAncestors} with {@link FullTermDtoWithAncestors#getAncestorTerms() fullParentTerms} set
      */
     @PreAuthorize("@termAuthorizationService.canRead(#term)")
-    public FullTermDtoWithParents resolveAllParents(Term term) {
+    public FullTermDtoWithAncestors resolveAllAncestors(Term term) {
         if (term.getParentTerms() == null) {
-            return dtoMapper.withFullParents(term, Set.of());
+            return dtoMapper.withAncestors(term, Set.of());
         }
         final Set<URI> directParentIdentifiers = term.getParentTerms()
                 .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
 
-        final Set<TermInfoWithParents> fullParents = findWithAllParents(directParentIdentifiers);
+        final Set<TermInfoWithParents> ancestors = findWithAllAncestors(directParentIdentifiers);
 
-        return dtoMapper.withFullParents(term, fullParents);
+        return dtoMapper.withAncestors(term, ancestors);
     }
 
     /**
-     * Finds all terms using their URIs including all their parents.
+     * Finds all terms using their URIs including all their ancestors.
+     * The terms and ancestors are filtered based on the current user authorizations.
      *
      * @param termUris term identifiers to find
-     * @return requested terms with their full parent chain
+     * @return requested terms with their full ancestor chain
      * @throws PersistenceException if any of the requested terms could not be found
      */
-    @PostAuthorize("@termAuthorizationService.canRead(returnObject.stream())")
-    public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
-        Set<TermInfoWithParents> fullTerms =
-                Collections.unmodifiableSet(repositoryService.findWithAllParents(termUris));
+    public Set<TermInfoWithParents> findWithAllAncestors(Set<URI> termUris) {
+        Set<TermInfoWithParents> ancestors =
+                new HashSet<>(repositoryService.findWithAllAncestors(termUris));
 
-        Set<URI> fullParentIdentifiers = fullTerms.stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
+        // verify that all requested terms were found
+        Set<URI> ancestorIds = ancestors.stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
         for (URI uri : termUris) {
-            if (!fullParentIdentifiers.contains(uri)) {
-                throw new PersistenceException("Failed to resolve all parent terms for term: " + uri);
+            if (!ancestorIds.contains(uri)) {
+                throw new PersistenceException("Failed to resolve all ancestors for term: " + uri);
             }
         }
-        return fullTerms;
+
+        termAuthorizationService.removeUnauthorizedTermsAndAncestors(ancestors);
+        return ancestors;
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -17,22 +17,27 @@
  */
 package cz.cvut.kbss.termit.service.business;
 
+import cz.cvut.kbss.termit.dto.FullTermDtoWithParents;
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermOccurrences;
 import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
+import cz.cvut.kbss.termit.dto.mapper.DtoMapper;
 import cz.cvut.kbss.termit.exception.InvalidTermStateException;
 import cz.cvut.kbss.termit.exception.NotFoundException;
+import cz.cvut.kbss.termit.exception.PersistenceException;
 import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.RdfsResource;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.assignment.TermDefinitionSource;
 import cz.cvut.kbss.termit.model.assignment.TermOccurrence;
 import cz.cvut.kbss.termit.model.changetracking.AbstractChangeRecord;
 import cz.cvut.kbss.termit.model.comment.Comment;
+import cz.cvut.kbss.termit.model.util.HasIdentifier;
 import cz.cvut.kbss.termit.persistence.context.VocabularyContextMapper;
 import cz.cvut.kbss.termit.service.business.util.TermSelectionParams;
 import cz.cvut.kbss.termit.service.changetracking.ChangeRecordProvider;
@@ -60,13 +65,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * Service for term-related business logic.
@@ -93,13 +100,14 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
     private final CommentService commentService;
 
     private final LanguageService languageService;
+    private final DtoMapper dtoMapper;
 
     @Autowired
     public TermService(VocabularyExporters exporters, VocabularyService vocabularyService,
                        VocabularyContextMapper vocabularyContextMapper,
                        TermRepositoryService repositoryService, TextAnalysisService textAnalysisService,
                        TermOccurrenceService termOccurrenceService, ChangeRecordService changeRecordService,
-                       CommentService commentService, LanguageService languageService) {
+                       CommentService commentService, LanguageService languageService, DtoMapper dtoMapper) {
         this.exporters = exporters;
         this.vocabularyService = vocabularyService;
         this.vocabularyContextMapper = vocabularyContextMapper;
@@ -109,6 +117,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         this.changeRecordService = changeRecordService;
         this.commentService = commentService;
         this.languageService = languageService;
+        this.dtoMapper = dtoMapper;
     }
 
     /**
@@ -388,6 +397,24 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         assert result != null;
         consolidateAttributes(result);
         return result;
+    }
+
+    @PreAuthorize("@termAuthorizationService.canRead(#term)")
+    public FullTermDtoWithParents resolveAllParents(Term term) {
+        final Set<URI> directParentIdentifiers = term.getParentTerms()
+                .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
+
+        Set<TermInfoWithParents> fullParents =
+                Collections.unmodifiableSet(repositoryService.findWithAllParents(directParentIdentifiers));
+
+        Set<URI> fullParentIdentifiers = fullParents.stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
+        for (URI uri : directParentIdentifiers) {
+            if (!fullParentIdentifiers.contains(uri)) {
+                throw new PersistenceException("Failed to resolve all parent terms for term: " + term.getUri());
+            }
+        }
+
+        return dtoMapper.withFullParents(term, fullParents);
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -403,10 +403,10 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
     }
 
     /**
-     * Resolves the full parent chain of the {@code term}.
+     * Resolves the full ancestors chain of the {@code term}.
      *
-     * @param term term for which the full parent chain should be resolved
-     * @return {@link FullTermDtoWithAncestors} with {@link FullTermDtoWithAncestors#getAncestorTerms() fullParentTerms} set
+     * @param term term for which the full ancestors chain should be resolved
+     * @return {@link FullTermDtoWithAncestors} with {@link FullTermDtoWithAncestors#getAncestorTerms() ancestorTerms} set
      */
     @PreAuthorize("@termAuthorizationService.canRead(#term)")
     public FullTermDtoWithAncestors resolveAllAncestors(Term term) {

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -404,17 +404,22 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         final Set<URI> directParentIdentifiers = term.getParentTerms()
                 .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
 
-        Set<TermInfoWithParents> fullParents =
-                Collections.unmodifiableSet(repositoryService.findWithAllParents(directParentIdentifiers));
-
-        Set<URI> fullParentIdentifiers = fullParents.stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
-        for (URI uri : directParentIdentifiers) {
-            if (!fullParentIdentifiers.contains(uri)) {
-                throw new PersistenceException("Failed to resolve all parent terms for term: " + term.getUri());
-            }
-        }
+        final Set<TermInfoWithParents> fullParents = findWithAllParents(directParentIdentifiers);
 
         return dtoMapper.withFullParents(term, fullParents);
+    }
+
+    public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
+        Set<TermInfoWithParents> fullTerms =
+                Collections.unmodifiableSet(repositoryService.findWithAllParents(termUris));
+
+        Set<URI> fullParentIdentifiers = fullTerms.stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
+        for (URI uri : termUris) {
+            if (!fullParentIdentifiers.contains(uri)) {
+                throw new PersistenceException("Failed to resolve all parent terms for term: " + uri);
+            }
+        }
+        return fullTerms;
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
@@ -23,9 +23,11 @@ import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.readonly.ReadOnlyTerm;
 import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.assignment.TermOccurrence;
 import cz.cvut.kbss.termit.model.comment.Comment;
+import cz.cvut.kbss.termit.model.util.HasIdentifier;
 import cz.cvut.kbss.termit.service.business.TermService;
 import cz.cvut.kbss.termit.service.business.util.TermSelectionParams;
 import cz.cvut.kbss.termit.util.Configuration;
@@ -39,6 +41,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 public class ReadOnlyTermService {
@@ -172,5 +176,13 @@ public class ReadOnlyTermService {
         Objects.requireNonNull(asset);
         final Term arg = toTerm(asset);
         return create(termService.findVersionValidAt(arg, at));
+    }
+
+    public void resolveAllParents(ReadOnlyTerm roTerm) {
+        final Set<URI> directParentIdentifiers = roTerm.getParentTerms()
+                                                     .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
+        // FIXME: This may cause unauthorized access to parent terms?
+        final Set<TermInfoWithParents> fullParents = termService.findWithAllParents(directParentIdentifiers);
+        roTerm.setParentTerms(Collections.unmodifiableSet(fullParents));
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
@@ -181,7 +181,6 @@ public class ReadOnlyTermService {
     public void resolveAllParents(ReadOnlyTerm roTerm) {
         final Set<URI> directParentIdentifiers = roTerm.getParentTerms()
                                                      .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
-        // FIXME: This may cause unauthorized access to parent terms?
         final Set<TermInfoWithParents> fullParents = termService.findWithAllParents(directParentIdentifiers);
         roTerm.setParentTerms(Collections.unmodifiableSet(fullParents));
     }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
@@ -178,10 +178,10 @@ public class ReadOnlyTermService {
         return create(termService.findVersionValidAt(arg, at));
     }
 
-    public void resolveAllParents(ReadOnlyTerm roTerm) {
+    public void resolveAllAncestors(ReadOnlyTerm roTerm) {
         final Set<URI> directParentIdentifiers = roTerm.getParentTerms()
                                                      .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
-        final Set<TermInfoWithParents> fullParents = termService.findWithAllParents(directParentIdentifiers);
-        roTerm.setParentTerms(Collections.unmodifiableSet(fullParents));
+        final Set<TermInfoWithParents> ancestors = termService.findWithAllAncestors(directParentIdentifiers);
+        roTerm.setParentTerms(Collections.unmodifiableSet(ancestors));
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -685,7 +685,7 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
     }
 
     @Transactional
-    public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
-        return termDao.findWithAllParents(termUris);
+    public Set<TermInfoWithParents> findWithAllAncestors(Set<URI> termUris) {
+        return termDao.findWithAllAncestors(termUris);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -30,6 +30,7 @@ import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.exception.UnsupportedOperationException;
 import cz.cvut.kbss.termit.model.CustomAttribute;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Term_;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.persistence.dao.BaseAssetDao;
@@ -681,5 +682,10 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
     @Override
     public Optional<Term> findVersionValidAt(Term asset, Instant at) {
         return termDao.findVersionValidAt(asset, at);
+    }
+
+    @Transactional
+    public Set<TermInfoWithParents> findWithAllParents(Set<URI> termUris) {
+        return termDao.findWithAllParents(termUris);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationService.java
@@ -17,13 +17,16 @@
  */
 package cz.cvut.kbss.termit.service.security.authorization;
 
-import cz.cvut.kbss.termit.dto.TermDescription;
 import cz.cvut.kbss.termit.model.AbstractTerm;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import org.springframework.stereotype.Service;
 
+import java.net.URI;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Authorizes access to terms.
@@ -87,15 +90,61 @@ public class TermAuthorizationService implements AssetAuthorizationService<Abstr
     }
 
     /**
-     * Checks that access to all the provided terms is allowed.
+     * Removes all terms from the collection in-place
+     * including their ancestors
+     * if the current user lacks authorization to read their associated vocabulary.
      *
-     * @param terms Collection of terms to check
-     * @return {@code true} if access is allowed for all terms, {@code false} otherwise
+     * @param terms mutable collection of terms to filter
      */
-    public boolean canRead(Collection<? extends TermDescription> terms) {
-        return terms.stream().map(TermDescription::getVocabulary)
-                    .distinct()
-                    .map(Vocabulary::new)
-                    .allMatch(vocabularyAuthorizationService::canRead);
+    public void removeUnauthorizedTermsAndAncestors(Collection<TermInfoWithParents> terms) {
+        Set<URI> vocabularies = new HashSet<>();
+        collectAllAncestorVocabularies(terms, vocabularies);
+
+        // remove vocabulary if user CAN access it
+        vocabularies.removeIf(vocabulary -> vocabularyAuthorizationService.canRead(new Vocabulary(vocabulary)));
+        // only unauthorized vocabularies left
+
+        removeTermsFromVocabularies(terms, vocabularies);
+    }
+
+    /**
+     * Collects all vocabulary identifiers of the terms and their ancestors into the {@code vocabularies} set
+     *
+     * @param terms terms from which vocabularies should be collected
+     * @param vocabularies modifiable set of vocabulary identifiers that should be filled
+     */
+    private void collectAllAncestorVocabularies(Collection<TermInfoWithParents> terms, Set<URI> vocabularies) {
+        if (terms == null) {
+            return;
+        }
+        terms.forEach(term -> {
+            if (term.getVocabulary() != null) {
+                vocabularies.add(term.getVocabulary());
+            }
+            collectAllAncestorVocabularies(term.getParentTerms(), vocabularies);
+        });
+    }
+
+    /**
+     * Recursively remove terms and their ancestors from the mutable collection
+     * if they belong in one of {@code unauthorizedVocabularies}.
+     *
+     * @param terms mutable collection of terms to filter
+     * @param unauthorizedVocabularies vocabulary identifiers to exclude
+     */
+    private void removeTermsFromVocabularies(Collection<TermInfoWithParents> terms, Set<URI> unauthorizedVocabularies) {
+        if (terms == null) {
+            return;
+        }
+
+        terms.removeIf(term -> unauthorizedVocabularies.contains(term.getVocabulary()));
+        terms.forEach(term -> {
+            try {
+                removeTermsFromVocabularies(term.getParentTerms(), unauthorizedVocabularies);
+            } catch (UnsupportedOperationException e) {
+                term.setParentTerms(new HashSet<>(term.getParentTerms()));
+                removeTermsFromVocabularies(term.getParentTerms(), unauthorizedVocabularies);
+            }
+        });
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationService.java
@@ -90,8 +90,7 @@ public class TermAuthorizationService implements AssetAuthorizationService<Abstr
     }
 
     /**
-     * Removes all terms from the collection in-place
-     * including their ancestors
+     * Removes all terms from the collection in-place including their ancestors
      * if the current user lacks authorization to read their associated vocabulary.
      *
      * @param terms mutable collection of terms to filter

--- a/src/main/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationService.java
@@ -17,10 +17,12 @@
  */
 package cz.cvut.kbss.termit.service.security.authorization;
 
+import cz.cvut.kbss.termit.dto.TermDescription;
 import cz.cvut.kbss.termit.model.AbstractTerm;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.Objects;
 
 /**
@@ -82,5 +84,18 @@ public class TermAuthorizationService implements AssetAuthorizationService<Abstr
     @Override
     public boolean canRemove(AbstractTerm asset) {
         return vocabularyAuthorizationService.canRemove(getVocabulary(asset));
+    }
+
+    /**
+     * Checks that access to all the provided terms is allowed.
+     *
+     * @param terms Collection of terms to check
+     * @return {@code true} if access is allowed for all terms, {@code false} otherwise
+     */
+    public boolean canRead(Collection<? extends TermDescription> terms) {
+        return terms.stream().map(TermDescription::getVocabulary)
+                    .distinct()
+                    .map(Vocabulary::new)
+                    .allMatch(vocabularyAuthorizationService::canRead);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
@@ -1594,6 +1594,26 @@ class TermDaoTest extends BaseTermDaoTestRunner {
         assertTrue(term3.getParentTerms().iterator().next().getParentTerms().isEmpty(), "Term4 must not have any parents");
     }
 
+    @Test
+    void findWithAllParentsReturnsEveryRequestedTerm() {
+        final Term t1 = Generator.generateTermWithId(vocabulary.getUri());
+        final Term t2 = Generator.generateTermWithId(vocabulary.getUri());
+        final Term t3 = Generator.generateTermWithId(vocabulary.getUri());
+
+        setPrimaryLabel(t1, "Alpha");
+        setPrimaryLabel(t2, "Beta");
+        setPrimaryLabel(t3, "Gamma");
+
+        addTermsAndSave(List.of(t1, t2, t3), vocabulary);
+
+        final Set<URI> requestedUris = Set.of(t1.getUri(), t3.getUri());
+
+        Set<TermInfoWithParents> terms = sut.findWithAllParents(requestedUris);
+        assertEquals(2, terms.size(), "Must return both requested terms");
+
+        assertTrue(terms.stream().map(HasIdentifier::getUri).collect(Collectors.toSet()).containsAll(requestedUris));
+    }
+
     static Set<URI> mapToIdentifiers(Collection<? extends HasIdentifier> withIdentifier) {
         return withIdentifier.stream().map(HasIdentifier::getUri)
                 .collect(Collectors.toSet());

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
@@ -1580,6 +1580,8 @@ class TermDaoTest extends BaseTermDaoTestRunner {
 
         TermInfoWithParents term2 = term1.getParentTerms().stream().filter(t -> t.getUri().equals(t2.getUri())).findFirst().orElseThrow();
         TermInfoWithParents term3 = term1.getParentTerms().stream().filter(t -> t.getUri().equals(t3.getUri())).findFirst().orElseThrow();
+        TermInfoWithParents term4 = term3.getParentTerms().stream().filter(t -> t.getUri().equals(t4.getUri())).findFirst().orElseThrow();
+        TermInfoWithParents term5 = term2.getParentTerms().stream().filter(t -> t.getUri().equals(t5.getUri())).findFirst().orElseThrow();
 
         assertEquals(1, term2.getParentTerms().size(), "Term2 must have only a single parent");
         assertEquals(1, term3.getParentTerms().size(), "Term3 must have only a single parent");
@@ -1590,12 +1592,12 @@ class TermDaoTest extends BaseTermDaoTestRunner {
         Set<URI> t3Parents = mapToIdentifiers(term3.getParentTerms());
         assertTrue(t3Parents.contains(t4.getUri()), "Term3 must have Term4 as parent");
 
-        assertTrue(term2.getParentTerms().iterator().next().getParentTerms().isEmpty(), "Term5 must not have any paretns");
-        assertTrue(term3.getParentTerms().iterator().next().getParentTerms().isEmpty(), "Term4 must not have any parents");
+        assertTrue(term5.getParentTerms().isEmpty(), "Term5 must not have any parents");
+        assertTrue(term4.getParentTerms().isEmpty(), "Term4 must not have any parents");
     }
 
     @Test
-    void findWithAllParentsReturnsEveryRequestedTerm() {
+    void findWithAllAncestorsReturnsEveryRequestedTerm() {
         final Term t1 = Generator.generateTermWithId(vocabulary.getUri());
         final Term t2 = Generator.generateTermWithId(vocabulary.getUri());
         final Term t3 = Generator.generateTermWithId(vocabulary.getUri());

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
@@ -22,6 +22,7 @@ import cz.cvut.kbss.jopa.model.query.TypedQuery;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.termit.dto.TermInfo;
+import cz.cvut.kbss.termit.dto.TermInfoWithParents;
 import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.environment.Environment;
@@ -1539,5 +1540,34 @@ class TermDaoTest extends BaseTermDaoTestRunner {
                                           .toList();
 
         assertEquals(List.of("Beta", "Delta"), labels);
+    }
+
+    @Test
+    void findWithAllParentsReturnsRequestedTermsWithAllParents() {
+        final Term t1 = Generator.generateTermWithId(vocabulary.getUri());
+        final Term t2 = Generator.generateTermWithId(vocabulary.getUri());
+        final Term t3 = Generator.generateTermWithId(vocabulary.getUri());
+        final Term t4 = Generator.generateTermWithId(vocabulary.getUri());
+        final Term t5 = Generator.generateTermWithId(vocabulary.getUri());
+
+        setPrimaryLabel(t1, "Alpha");
+        setPrimaryLabel(t2, "Beta");
+        setPrimaryLabel(t3, "Gamma");
+        setPrimaryLabel(t4, "Delta");
+        setPrimaryLabel(t5, "Epsilon");
+
+        t1.addParentTerm(t2);
+        t1.addParentTerm(t3);
+        t3.addParentTerm(t4);
+        t2.addParentTerm(t5);
+
+        addTermsAndSave(List.of(t5), vocabulary);
+        addTermsAndSave(List.of(t4), vocabulary);
+        addTermsAndSave(List.of(t3), vocabulary);
+        addTermsAndSave(List.of(t2), vocabulary);
+        addTermsAndSave(List.of(t1), vocabulary);
+
+        List<TermInfoWithParents> dtos = sut.findWithAllParents(Set.of(t1.getUri()));
+        assertFalse(dtos.isEmpty());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
@@ -22,7 +22,6 @@ import cz.cvut.kbss.jopa.model.query.TypedQuery;
 import cz.cvut.kbss.jopa.vocabulary.DC;
 import cz.cvut.kbss.jopa.vocabulary.SKOS;
 import cz.cvut.kbss.termit.dto.TermInfo;
-import cz.cvut.kbss.termit.dto.TermInfoWithParents;
 import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.environment.Environment;
@@ -32,12 +31,14 @@ import cz.cvut.kbss.termit.event.AssetUpdateEvent;
 import cz.cvut.kbss.termit.event.VocabularyContentModifiedEvent;
 import cz.cvut.kbss.termit.model.Asset;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Term_;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.assignment.FileOccurrenceTarget;
 import cz.cvut.kbss.termit.model.assignment.TermDefinitionSource;
 import cz.cvut.kbss.termit.model.resource.File;
 import cz.cvut.kbss.termit.model.selector.TextQuoteSelector;
+import cz.cvut.kbss.termit.model.util.HasIdentifier;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Constants;
 import org.eclipse.rdf4j.model.IRI;
@@ -1567,7 +1568,34 @@ class TermDaoTest extends BaseTermDaoTestRunner {
         addTermsAndSave(List.of(t2), vocabulary);
         addTermsAndSave(List.of(t1), vocabulary);
 
-        List<TermInfoWithParents> dtos = sut.findWithAllParents(Set.of(t1.getUri()));
-        assertFalse(dtos.isEmpty());
+        Set<TermInfoWithParents> terms = sut.findWithAllParents(Set.of(t1.getUri()));
+
+        assertEquals(1, terms.size(), "Term1 must be the only returned term");
+        final TermInfoWithParents term1 = terms.iterator().next();
+        assertEquals(t1.getUri(), term1.getUri());
+
+        assertEquals(2, term1.getParentTerms().size(), "Term1 must have two parents");
+        Set<URI> t1Parents = mapToIdentifiers(term1.getParentTerms());
+        assertTrue(t1Parents.containsAll(Set.of(t2.getUri(), t3.getUri())), "Term1 must have Term2 and Term3 as parents");
+
+        TermInfoWithParents term2 = term1.getParentTerms().stream().filter(t -> t.getUri().equals(t2.getUri())).findFirst().orElseThrow();
+        TermInfoWithParents term3 = term1.getParentTerms().stream().filter(t -> t.getUri().equals(t3.getUri())).findFirst().orElseThrow();
+
+        assertEquals(1, term2.getParentTerms().size(), "Term2 must have only a single parent");
+        assertEquals(1, term3.getParentTerms().size(), "Term3 must have only a single parent");
+
+        Set<URI> t2Parents = mapToIdentifiers(term2.getParentTerms());
+        assertTrue(t2Parents.contains(t5.getUri()), "Term2 must have Term5 as parent");
+
+        Set<URI> t3Parents = mapToIdentifiers(term3.getParentTerms());
+        assertTrue(t3Parents.contains(t4.getUri()), "Term3 must have Term4 as parent");
+
+        assertTrue(term2.getParentTerms().iterator().next().getParentTerms().isEmpty(), "Term5 must not have any paretns");
+        assertTrue(term3.getParentTerms().iterator().next().getParentTerms().isEmpty(), "Term4 must not have any parents");
+    }
+
+    static Set<URI> mapToIdentifiers(Collection<? extends HasIdentifier> withIdentifier) {
+        return withIdentifier.stream().map(HasIdentifier::getUri)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/TermDaoTest.java
@@ -1544,7 +1544,7 @@ class TermDaoTest extends BaseTermDaoTestRunner {
     }
 
     @Test
-    void findWithAllParentsReturnsRequestedTermsWithAllParents() {
+    void findWithAllAncestorsReturnsRequestedTermsWithAllAncestors() {
         final Term t1 = Generator.generateTermWithId(vocabulary.getUri());
         final Term t2 = Generator.generateTermWithId(vocabulary.getUri());
         final Term t3 = Generator.generateTermWithId(vocabulary.getUri());
@@ -1568,7 +1568,7 @@ class TermDaoTest extends BaseTermDaoTestRunner {
         addTermsAndSave(List.of(t2), vocabulary);
         addTermsAndSave(List.of(t1), vocabulary);
 
-        Set<TermInfoWithParents> terms = sut.findWithAllParents(Set.of(t1.getUri()));
+        Set<TermInfoWithParents> terms = sut.findWithAllAncestors(Set.of(t1.getUri()));
 
         assertEquals(1, terms.size(), "Term1 must be the only returned term");
         final TermInfoWithParents term1 = terms.iterator().next();
@@ -1608,7 +1608,7 @@ class TermDaoTest extends BaseTermDaoTestRunner {
 
         final Set<URI> requestedUris = Set.of(t1.getUri(), t3.getUri());
 
-        Set<TermInfoWithParents> terms = sut.findWithAllParents(requestedUris);
+        Set<TermInfoWithParents> terms = sut.findWithAllAncestors(requestedUris);
         assertEquals(2, terms.size(), "Must return both requested terms");
 
         assertTrue(terms.stream().map(HasIdentifier::getUri).collect(Collectors.toSet()).containsAll(requestedUris));

--- a/src/test/java/cz/cvut/kbss/termit/rest/TermControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/TermControllerTest.java
@@ -1322,6 +1322,43 @@ public class TermControllerTest extends BaseControllerTestRunner {
         verify(termServiceMock, never()).findAll(anyString(), eq(PageRequest.of(2, 50)), anyCollection());
     }
 
+    @Test
+    void getByIdResolvesAllParentsWhenLoadAllParentsIsRequested() throws Exception {
+        final Term term = Generator.generateTerm();
+        term.setUri(URI.create(NAMESPACE + TERM_NAME));
+
+        when(namespaceResolver.resolveNamespace(URI.create(VOCABULARY_URI))).thenReturn(NAMESPACE);
+        when(idResolverMock.resolveIdentifier(Environment.BASE_URI, VOCABULARY_NAME)).thenReturn(URI.create(VOCABULARY_URI));
+        when(idResolverMock.resolveIdentifier(NAMESPACE, TERM_NAME)).thenReturn(term.getUri());
+        when(termServiceMock.findRequired(any())).thenReturn(term);
+
+        mockMvc.perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME)
+                       .param(Constants.QueryParams.NAMESPACE, Environment.BASE_URI)
+                       .param("loadAllParents", "true")
+               )
+               .andExpect(status().isOk());
+
+        verify(termServiceMock).resolveAllParents(term);
+    }
+
+    @Test
+    void getByIdDoesNotResolvesAllParentsByDefault() throws Exception {
+        final Term term = Generator.generateTerm();
+        term.setUri(URI.create(NAMESPACE + TERM_NAME));
+
+        when(namespaceResolver.resolveNamespace(URI.create(VOCABULARY_URI))).thenReturn(NAMESPACE);
+        when(idResolverMock.resolveIdentifier(Environment.BASE_URI, VOCABULARY_NAME)).thenReturn(URI.create(VOCABULARY_URI));
+        when(idResolverMock.resolveIdentifier(NAMESPACE, TERM_NAME)).thenReturn(term.getUri());
+        when(termServiceMock.findRequired(any())).thenReturn(term);
+
+        mockMvc.perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME)
+                       .param(Constants.QueryParams.NAMESPACE, Environment.BASE_URI)
+               )
+               .andExpect(status().isOk());
+
+        verify(termServiceMock, never()).resolveAllParents(term);
+    }
+
     public static class TermSelectionParamsBuilder {
         private boolean flat = false;
         private boolean includeImported = false;

--- a/src/test/java/cz/cvut/kbss/termit/rest/TermControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/TermControllerTest.java
@@ -1323,7 +1323,7 @@ public class TermControllerTest extends BaseControllerTestRunner {
     }
 
     @Test
-    void getByIdResolvesAllParentsWhenLoadAllParentsIsRequested() throws Exception {
+    void getByIdResolvesAllAncestorsWhenWithAncestorsIsRequested() throws Exception {
         final Term term = Generator.generateTerm();
         term.setUri(URI.create(NAMESPACE + TERM_NAME));
 
@@ -1334,15 +1334,15 @@ public class TermControllerTest extends BaseControllerTestRunner {
 
         mockMvc.perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME)
                        .param(Constants.QueryParams.NAMESPACE, Environment.BASE_URI)
-                       .param("loadAllParents", "true")
+                       .param("withAncestors", "true")
                )
                .andExpect(status().isOk());
 
-        verify(termServiceMock).resolveAllParents(term);
+        verify(termServiceMock).resolveAllAncestors(term);
     }
 
     @Test
-    void getByIdDoesNotResolvesAllParentsByDefault() throws Exception {
+    void getByIdDoesNotResolvesAllAncestorsByDefault() throws Exception {
         final Term term = Generator.generateTerm();
         term.setUri(URI.create(NAMESPACE + TERM_NAME));
 
@@ -1356,7 +1356,7 @@ public class TermControllerTest extends BaseControllerTestRunner {
                )
                .andExpect(status().isOk());
 
-        verify(termServiceMock, never()).resolveAllParents(term);
+        verify(termServiceMock, never()).resolveAllAncestors(term);
     }
 
     public static class TermSelectionParamsBuilder {

--- a/src/test/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermControllerTest.java
@@ -66,6 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -387,5 +388,42 @@ class ReadOnlyTermControllerTest extends BaseControllerTestRunner {
         assertThat(result, containsSameEntities(occurrences));
         verify(termService).getReference(termUri);
         verify(termService).getDefinitionallyRelatedTargeting(term);
+    }
+
+    @Test
+    void getByIdResolvesAllParentsWhenLoadAllParentsIsRequested() throws Exception {
+        final ReadOnlyTerm term = new ReadOnlyTerm(Generator.generateTerm());
+        term.setUri(URI.create(NAMESPACE + TERM_NAME));
+
+        when(namespaceResolver.resolveNamespace(URI.create(VOCABULARY_URI))).thenReturn(NAMESPACE);
+        when(idResolver.resolveIdentifier(Environment.BASE_URI, VOCABULARY_NAME)).thenReturn(URI.create(VOCABULARY_URI));
+        when(idResolver.resolveIdentifier(NAMESPACE, TERM_NAME)).thenReturn(term.getUri());
+        when(termService.findRequired(any())).thenReturn(term);
+
+        mockMvc.perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME)
+                       .param(Constants.QueryParams.NAMESPACE, Environment.BASE_URI)
+                       .param("loadAllParents", "true")
+               )
+               .andExpect(status().isOk());
+
+        verify(termService).resolveAllParents(term);
+    }
+
+    @Test
+    void getByIdDoesNotResolvesAllParentsByDefault() throws Exception {
+        final ReadOnlyTerm term = new ReadOnlyTerm(Generator.generateTerm());
+        term.setUri(URI.create(NAMESPACE + TERM_NAME));
+
+        when(namespaceResolver.resolveNamespace(URI.create(VOCABULARY_URI))).thenReturn(NAMESPACE);
+        when(idResolver.resolveIdentifier(Environment.BASE_URI, VOCABULARY_NAME)).thenReturn(URI.create(VOCABULARY_URI));
+        when(idResolver.resolveIdentifier(NAMESPACE, TERM_NAME)).thenReturn(term.getUri());
+        when(termService.findRequired(any())).thenReturn(term);
+
+        mockMvc.perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME)
+                       .param(Constants.QueryParams.NAMESPACE, Environment.BASE_URI)
+               )
+               .andExpect(status().isOk());
+
+        verify(termService, never()).resolveAllParents(term);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermControllerTest.java
@@ -410,7 +410,7 @@ class ReadOnlyTermControllerTest extends BaseControllerTestRunner {
     }
 
     @Test
-    void getByIdDoesNotResolvesAllParentsByDefault() throws Exception {
+    void getByIdDoesNotResolvesAllAncestorsByDefault() throws Exception {
         final ReadOnlyTerm term = new ReadOnlyTerm(Generator.generateTerm());
         term.setUri(URI.create(NAMESPACE + TERM_NAME));
 

--- a/src/test/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermControllerTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermControllerTest.java
@@ -391,7 +391,7 @@ class ReadOnlyTermControllerTest extends BaseControllerTestRunner {
     }
 
     @Test
-    void getByIdResolvesAllParentsWhenLoadAllParentsIsRequested() throws Exception {
+    void getByIdResolvesAllAncestorsWhenWithAncestorsIsRequested() throws Exception {
         final ReadOnlyTerm term = new ReadOnlyTerm(Generator.generateTerm());
         term.setUri(URI.create(NAMESPACE + TERM_NAME));
 
@@ -402,11 +402,11 @@ class ReadOnlyTermControllerTest extends BaseControllerTestRunner {
 
         mockMvc.perform(get(PATH + VOCABULARY_NAME + "/terms/" + TERM_NAME)
                        .param(Constants.QueryParams.NAMESPACE, Environment.BASE_URI)
-                       .param("loadAllParents", "true")
+                       .param("withAncestors", "true")
                )
                .andExpect(status().isOk());
 
-        verify(termService).resolveAllParents(term);
+        verify(termService).resolveAllAncestors(term);
     }
 
     @Test
@@ -424,6 +424,6 @@ class ReadOnlyTermControllerTest extends BaseControllerTestRunner {
                )
                .andExpect(status().isOk());
 
-        verify(termService, never()).resolveAllParents(term);
+        verify(termService, never()).resolveAllAncestors(term);
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -765,7 +765,7 @@ class TermServiceTest {
 
         assertEquals(term.getUri(), result.getUri());
         assertTrue(result.getFullParentTerms().isEmpty());
-        verify(termRepositoryService, never()).findWithAllParents(any());
+        verify(termRepositoryService).findWithAllParents(eq(Set.of()));
     }
 
 

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -48,6 +48,7 @@ import cz.cvut.kbss.termit.service.export.VocabularyExporters;
 import cz.cvut.kbss.termit.service.language.LanguageService;
 import cz.cvut.kbss.termit.service.repository.ChangeRecordService;
 import cz.cvut.kbss.termit.service.repository.TermRepositoryService;
+import cz.cvut.kbss.termit.service.security.authorization.TermAuthorizationService;
 import cz.cvut.kbss.termit.util.Configuration;
 import cz.cvut.kbss.termit.util.Constants;
 import cz.cvut.kbss.termit.util.TypeAwareByteArrayResource;
@@ -88,6 +89,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyCollection;
 import static org.mockito.Mockito.eq;
@@ -132,6 +134,9 @@ class TermServiceTest {
 
     @Spy
     private DtoMapper dtoMapper = new DtoMapperImpl();
+
+    @Mock
+    private TermAuthorizationService termAuthorizationService;
 
     @InjectMocks
     private TermService sut;
@@ -770,7 +775,7 @@ class TermServiceTest {
 
 
     @Test
-    void resolveAllParentsResolvesFullParentChainUsingDirectParentIdentifiersOfTerm() {
+    void resolveAllAncestorsResolvesFullAncestorsChainUsingDirectAncestorIdentifiersOfTerm() {
         final Term term = generateTermWithId(vocabulary.getUri());
         final TermInfo directParentOne = Generator.generateTermInfoWithId();
         final TermInfo directParentTwo = Generator.generateTermInfoWithId();
@@ -790,6 +795,17 @@ class TermServiceTest {
         assertEquals(fullParents, result.getAncestorTerms());
         verify(termRepositoryService).findWithAllAncestors(directParentIdentifiers);
         verify(dtoMapper).withAncestors(term, fullParents);
+    }
+
+    @Test
+    void resolveAllAncestorsFiltersAncestorsWithTermAuthorizationService() {
+        final Term term = Generator.generateTermWithId();
+        final Set<TermInfo> parentTerms = Set.of();
+        term.setParentTerms(parentTerms);
+
+        sut.resolveAllAncestors(term);
+
+        verify(termAuthorizationService).removeUnauthorizedTermsAndAncestors(notNull());
     }
 
 

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -18,17 +18,21 @@
 package cz.cvut.kbss.termit.service.business;
 
 import cz.cvut.kbss.jopa.model.MultilingualString;
+import cz.cvut.kbss.termit.dto.FullTermDtoWithParents;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermOccurrences;
 import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
+import cz.cvut.kbss.termit.dto.mapper.DtoMapper;
+import cz.cvut.kbss.termit.dto.mapper.DtoMapperImpl;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.exception.InvalidTermStateException;
 import cz.cvut.kbss.termit.exception.NotFoundException;
-import cz.cvut.kbss.termit.model.AbstractTerm;
+import cz.cvut.kbss.termit.exception.PersistenceException;
 import cz.cvut.kbss.termit.model.RdfsResource;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.assignment.FileOccurrenceTarget;
 import cz.cvut.kbss.termit.model.assignment.TermDefinitionSource;
@@ -50,6 +54,7 @@ import cz.cvut.kbss.termit.util.TypeAwareByteArrayResource;
 import cz.cvut.kbss.termit.util.TypeAwareResource;
 import cz.cvut.kbss.termit.util.Utils;
 import org.apache.commons.lang3.function.TriConsumer;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -125,10 +130,18 @@ class TermServiceTest {
     @Spy
     private Configuration configuration = new Configuration();
 
+    @Spy
+    private DtoMapper dtoMapper = new DtoMapperImpl();
+
     @InjectMocks
     private TermService sut;
 
     private final Vocabulary vocabulary = Generator.generateVocabularyWithId();
+
+    @BeforeEach
+    void setUp() {
+        dtoMapper.setConfig(configuration);
+    }
 
     @Test
     void exportGlossaryGetsGlossaryExportForSpecifiedVocabularyFromExporters() {
@@ -704,6 +717,81 @@ class TermServiceTest {
         sut.findAll(vocabulary, params);
         verifier.accept(termRepositoryService, vocabulary);
     }
+
+    @Test
+    void findWithAllParentsReturnsTermsWithParentsResolvedByRepositoryService() {
+        final TermInfoWithParents t1 = new TermInfoWithParents();
+        final TermInfoWithParents t2 = new TermInfoWithParents();
+        t1.setUri(Generator.generateUri());
+        t2.setUri(Generator.generateUri());
+
+        final Set<URI> termUris = Set.of(t1.getUri(), t2.getUri());
+        when(termRepositoryService.findWithAllParents(termUris)).thenReturn(Set.of(t1, t2));
+
+        final Set<TermInfoWithParents> result = sut.findWithAllParents(termUris);
+
+        assertEquals(Set.of(t1, t2), result);
+        verify(termRepositoryService).findWithAllParents(termUris);
+    }
+
+    @Test
+    void findWithAllParentsThrowsPersistenceExceptionWhenRepositoryServiceDoesNotResolveAllRequestedTerms() {
+        final TermInfoWithParents t1 = new TermInfoWithParents();
+        t1.setUri(Generator.generateUri());
+
+        final Set<URI> termUris = Set.of(t1.getUri(), Generator.generateUri());
+        // Returning only one term and leaving other unresolved
+        when(termRepositoryService.findWithAllParents(termUris)).thenReturn(Set.of(t1));
+
+        assertThrows(PersistenceException.class, () -> sut.findWithAllParents(termUris));
+    }
+
+    @Test
+    void findWithAllParentsReturnsEmptySetWhenNoTermUrisAreSpecified() {
+        final Set<URI> termUris = Set.of();
+        when(termRepositoryService.findWithAllParents(termUris)).thenReturn(Set.of());
+
+        final Set<TermInfoWithParents> result = sut.findWithAllParents(termUris);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void resolveAllParentsReturnsDtoWithEmptyParentsWhenTermHasNoParentTerms() {
+        final Term term = generateTermWithId(vocabulary.getUri());
+        term.setParentTerms(Set.of());
+
+        final FullTermDtoWithParents result = sut.resolveAllParents(term);
+
+        assertEquals(term.getUri(), result.getUri());
+        assertTrue(result.getFullParentTerms().isEmpty());
+        verify(termRepositoryService, never()).findWithAllParents(any());
+    }
+
+
+    @Test
+    void resolveAllParentsResolvesFullParentChainUsingDirectParentIdentifiersOfTerm() {
+        final Term term = generateTermWithId(vocabulary.getUri());
+        final TermInfo directParentOne = Generator.generateTermInfoWithId();
+        final TermInfo directParentTwo = Generator.generateTermInfoWithId();
+        term.setParentTerms(Set.of(directParentOne, directParentTwo));
+        final Set<URI> directParentIdentifiers = Set.of(directParentOne.getUri(), directParentTwo.getUri());
+
+        final TermInfoWithParents resolvedParentOne = new TermInfoWithParents();
+        resolvedParentOne.setUri(directParentOne.getUri());
+        final TermInfoWithParents resolvedParentTwo = new TermInfoWithParents();
+        resolvedParentTwo.setUri(directParentTwo.getUri());
+        final Set<TermInfoWithParents> fullParents = Set.of(resolvedParentOne, resolvedParentTwo);
+        when(termRepositoryService.findWithAllParents(directParentIdentifiers)).thenReturn(fullParents);
+
+        final FullTermDtoWithParents result = sut.resolveAllParents(term);
+
+        assertEquals(term.getUri(), result.getUri());
+        assertEquals(fullParents, result.getFullParentTerms());
+        verify(termRepositoryService).findWithAllParents(directParentIdentifiers);
+        verify(dtoMapper).withFullParents(term, fullParents);
+    }
+
 
     static Stream<Arguments> findAllParams() {
         return Stream.of(

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -18,7 +18,7 @@
 package cz.cvut.kbss.termit.service.business;
 
 import cz.cvut.kbss.jopa.model.MultilingualString;
-import cz.cvut.kbss.termit.dto.FullTermDtoWithParents;
+import cz.cvut.kbss.termit.dto.FullTermDtoWithAncestors;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.assignment.TermOccurrences;
 import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
@@ -719,53 +719,53 @@ class TermServiceTest {
     }
 
     @Test
-    void findWithAllParentsReturnsTermsWithParentsResolvedByRepositoryService() {
+    void findWithAllAncestorsReturnsTermsWithAncestorsResolvedByRepositoryService() {
         final TermInfoWithParents t1 = new TermInfoWithParents();
         final TermInfoWithParents t2 = new TermInfoWithParents();
         t1.setUri(Generator.generateUri());
         t2.setUri(Generator.generateUri());
 
         final Set<URI> termUris = Set.of(t1.getUri(), t2.getUri());
-        when(termRepositoryService.findWithAllParents(termUris)).thenReturn(Set.of(t1, t2));
+        when(termRepositoryService.findWithAllAncestors(termUris)).thenReturn(Set.of(t1, t2));
 
-        final Set<TermInfoWithParents> result = sut.findWithAllParents(termUris);
+        final Set<TermInfoWithParents> result = sut.findWithAllAncestors(termUris);
 
         assertEquals(Set.of(t1, t2), result);
-        verify(termRepositoryService).findWithAllParents(termUris);
+        verify(termRepositoryService).findWithAllAncestors(termUris);
     }
 
     @Test
-    void findWithAllParentsThrowsPersistenceExceptionWhenRepositoryServiceDoesNotResolveAllRequestedTerms() {
+    void findWithAllAncestorsThrowsPersistenceExceptionWhenRepositoryServiceDoesNotResolveAllRequestedTerms() {
         final TermInfoWithParents t1 = new TermInfoWithParents();
         t1.setUri(Generator.generateUri());
 
         final Set<URI> termUris = Set.of(t1.getUri(), Generator.generateUri());
         // Returning only one term and leaving other unresolved
-        when(termRepositoryService.findWithAllParents(termUris)).thenReturn(Set.of(t1));
+        when(termRepositoryService.findWithAllAncestors(termUris)).thenReturn(Set.of(t1));
 
-        assertThrows(PersistenceException.class, () -> sut.findWithAllParents(termUris));
+        assertThrows(PersistenceException.class, () -> sut.findWithAllAncestors(termUris));
     }
 
     @Test
-    void findWithAllParentsReturnsEmptySetWhenNoTermUrisAreSpecified() {
+    void findWithAllAncestorsReturnsEmptySetWhenNoTermUrisAreSpecified() {
         final Set<URI> termUris = Set.of();
-        when(termRepositoryService.findWithAllParents(termUris)).thenReturn(Set.of());
+        when(termRepositoryService.findWithAllAncestors(termUris)).thenReturn(Set.of());
 
-        final Set<TermInfoWithParents> result = sut.findWithAllParents(termUris);
+        final Set<TermInfoWithParents> result = sut.findWithAllAncestors(termUris);
 
         assertTrue(result.isEmpty());
     }
 
     @Test
-    void resolveAllParentsReturnsDtoWithEmptyParentsWhenTermHasNoParentTerms() {
+    void resolveAllAncestorsReturnsDtoWithEmptyAncestorsWhenTermHasNoAncestors() {
         final Term term = generateTermWithId(vocabulary.getUri());
         term.setParentTerms(Set.of());
 
-        final FullTermDtoWithParents result = sut.resolveAllParents(term);
+        final FullTermDtoWithAncestors result = sut.resolveAllAncestors(term);
 
         assertEquals(term.getUri(), result.getUri());
-        assertTrue(result.getFullParentTerms().isEmpty());
-        verify(termRepositoryService).findWithAllParents(eq(Set.of()));
+        assertTrue(result.getAncestorTerms().isEmpty());
+        verify(termRepositoryService).findWithAllAncestors(eq(Set.of()));
     }
 
 
@@ -782,14 +782,14 @@ class TermServiceTest {
         final TermInfoWithParents resolvedParentTwo = new TermInfoWithParents();
         resolvedParentTwo.setUri(directParentTwo.getUri());
         final Set<TermInfoWithParents> fullParents = Set.of(resolvedParentOne, resolvedParentTwo);
-        when(termRepositoryService.findWithAllParents(directParentIdentifiers)).thenReturn(fullParents);
+        when(termRepositoryService.findWithAllAncestors(directParentIdentifiers)).thenReturn(fullParents);
 
-        final FullTermDtoWithParents result = sut.resolveAllParents(term);
+        final FullTermDtoWithAncestors result = sut.resolveAllAncestors(term);
 
         assertEquals(term.getUri(), result.getUri());
-        assertEquals(fullParents, result.getFullParentTerms());
-        verify(termRepositoryService).findWithAllParents(directParentIdentifiers);
-        verify(dtoMapper).withFullParents(term, fullParents);
+        assertEquals(fullParents, result.getAncestorTerms());
+        verify(termRepositoryService).findWithAllAncestors(directParentIdentifiers);
+        verify(dtoMapper).withAncestors(term, fullParents);
     }
 
 

--- a/src/test/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermServiceTest.java
@@ -24,6 +24,7 @@ import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.readonly.ReadOnlyTerm;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import cz.cvut.kbss.termit.model.assignment.TermOccurrence;
 import cz.cvut.kbss.termit.model.comment.Comment;
@@ -41,10 +42,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -53,7 +56,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
@@ -235,5 +240,29 @@ class ReadOnlyTermServiceTest {
         assertThat(result.getProperties(), hasEntry(DC.Terms.REFERENCES, term.getProperties()
                                                                              .get(DC.Terms.REFERENCES)));
         assertThat(result.getProperties(), not(hasEntry(DC.Elements.DATE, term.getProperties().get(DC.Elements.DATE))));
+    }
+
+    @Test
+    void resolveAllParentsRetrievesAllParentsFromService() {
+        final Term term = Generator.generateTermWithId();
+        term.setParentTerms(Set.of(Generator.generateTermInfoWithId(), Generator.generateTermInfoWithId(), Generator.generateTermInfoWithId()));
+        final ReadOnlyTerm roTerm = new ReadOnlyTerm(term);
+        final Set<TermInfoWithParents> resolvedParents = Set.of();
+
+        assertNotEquals(resolvedParents, roTerm.getParentTerms());
+
+        when(termService.findWithAllParents(any())).thenReturn(resolvedParents);
+
+        ArgumentCaptor<Set<URI>> requestedUris = ArgumentCaptor.captor();
+        sut.resolveAllParents(roTerm);
+
+        verify(termService).findWithAllParents(requestedUris.capture());
+
+        assertEquals(term.getParentTerms().size(), requestedUris.getValue().size());
+        for (TermInfo t : term.getParentTerms()) {
+            assertTrue(requestedUris.getValue().contains(t.getUri()));
+        }
+
+        assertEquals(resolvedParents, roTerm.getParentTerms());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermServiceTest.java
@@ -243,26 +243,26 @@ class ReadOnlyTermServiceTest {
     }
 
     @Test
-    void resolveAllParentsRetrievesAllParentsFromService() {
+    void resolveAllAncestorsRetrievesAllAncestorsFromService() {
         final Term term = Generator.generateTermWithId();
         term.setParentTerms(Set.of(Generator.generateTermInfoWithId(), Generator.generateTermInfoWithId(), Generator.generateTermInfoWithId()));
         final ReadOnlyTerm roTerm = new ReadOnlyTerm(term);
-        final Set<TermInfoWithParents> resolvedParents = Set.of();
+        final Set<TermInfoWithParents> resolvedAncestors = Set.of();
 
-        assertNotEquals(resolvedParents, roTerm.getParentTerms());
+        assertNotEquals(resolvedAncestors, roTerm.getParentTerms());
 
-        when(termService.findWithAllParents(any())).thenReturn(resolvedParents);
+        when(termService.findWithAllAncestors(any())).thenReturn(resolvedAncestors);
 
         ArgumentCaptor<Set<URI>> requestedUris = ArgumentCaptor.captor();
-        sut.resolveAllParents(roTerm);
+        sut.resolveAllAncestors(roTerm);
 
-        verify(termService).findWithAllParents(requestedUris.capture());
+        verify(termService).findWithAllAncestors(requestedUris.capture());
 
         assertEquals(term.getParentTerms().size(), requestedUris.getValue().size());
         for (TermInfo t : term.getParentTerms()) {
             assertTrue(requestedUris.getValue().contains(t.getUri()));
         }
 
-        assertEquals(resolvedParents, roTerm.getParentTerms());
+        assertEquals(resolvedAncestors, roTerm.getParentTerms());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationServiceTest.java
@@ -19,6 +19,7 @@ package cz.cvut.kbss.termit.service.security.authorization;
 
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.model.Term;
+import cz.cvut.kbss.termit.model.TermInfoWithParents;
 import cz.cvut.kbss.termit.model.Vocabulary;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,13 +27,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashSet;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -95,34 +97,62 @@ class TermAuthorizationServiceTest {
         verify(vocabularyAuthorizationService).canRemove(v);
     }
 
-    @Test
-    void canReadTermCollectionChecksIfUserCanReadTermVocabularies() {
-        when(vocabularyAuthorizationService.canRead(any(Vocabulary.class))).thenReturn(true);
-        final Term term = Generator.generateTermWithId();
-        final Term term2 = Generator.generateTermWithId();
-        final Vocabulary v = Generator.generateVocabularyWithId();
-        final Vocabulary v2 = Generator.generateVocabularyWithId();
-        term.setVocabulary(v.getUri());
-        term2.setVocabulary(v2.getUri());
 
-        assertTrue(sut.canRead(Set.of(term, term2)));
-        verify(vocabularyAuthorizationService).canRead(v);
+    @Test
+    void removeUnauthorizedTermsAndAncestorsRemovesTermsFromUnauthorizedVocabulary() {
+        final Vocabulary authorizedVoc = Generator.generateVocabularyWithId();
+        final Vocabulary unauthorizedVoc = Generator.generateVocabularyWithId();
+
+        final TermInfoWithParents term = new TermInfoWithParents();
+        term.setUri(Generator.generateUri());
+        term.setVocabulary(authorizedVoc.getUri());
+        final TermInfoWithParents term2 = new TermInfoWithParents();
+        term2.setUri(Generator.generateUri());
+        term2.setVocabulary(unauthorizedVoc.getUri());
+
+        doAnswer(inv ->
+            inv.getArgument(0, Vocabulary.class).getUri().equals(authorizedVoc.getUri())
+        ).when(vocabularyAuthorizationService).canRead(any(Vocabulary.class));
+
+        Set<TermInfoWithParents> terms = new HashSet<>(Set.of(term, term2));
+
+        sut.removeUnauthorizedTermsAndAncestors(terms);
+
+        assertEquals(1, terms.size());
+        assertTrue(terms.contains(term));
+        assertFalse(terms.contains(term2));
     }
 
     @Test
-    void canReadTermCollectionReturnsFalseIfUserCannotReadTermVocabularies() {
-        final Term term = Generator.generateTermWithId();
-        final Term term2 = Generator.generateTermWithId();
-        final Vocabulary v = Generator.generateVocabularyWithId();
-        final Vocabulary v2 = Generator.generateVocabularyWithId();
-        term.setVocabulary(v.getUri());
-        term2.setVocabulary(v2.getUri());
+    void removeUnauthorizedTermsAndAncestorsRemovesAncestorsFromUnauthorizedVocabulary() {
+        final Vocabulary authorizedVocabulary = Generator.generateVocabularyWithId();
+        final Vocabulary unauthorizedVocabulary = Generator.generateVocabularyWithId();
 
-        // lenient because of the process order is unknown and hence this stub may be unnecessary in some executions
-        lenient().when(vocabularyAuthorizationService.canRead(v)).thenReturn(true);
-        when(vocabularyAuthorizationService.canRead(v2)).thenReturn(false);
+        final TermInfoWithParents term = new TermInfoWithParents();
+        term.setUri(Generator.generateUri());
+        term.setVocabulary(authorizedVocabulary.getUri());
+        final TermInfoWithParents term2 = new TermInfoWithParents();
+        term2.setUri(Generator.generateUri());
+        term2.setVocabulary(authorizedVocabulary.getUri());
+        final TermInfoWithParents term3 = new TermInfoWithParents();
+        term3.setUri(Generator.generateUri());
+        term3.setVocabulary(unauthorizedVocabulary.getUri());
 
-        assertFalse(sut.canRead(Set.of(term, term2)));
-        verify(vocabularyAuthorizationService, atLeastOnce()).canRead(any(Vocabulary.class));
+        term.setParentTerms(Set.of(term2));
+        term2.setParentTerms(Set.of(term3));
+
+        doAnswer(inv ->
+                inv.getArgument(0, Vocabulary.class).getUri().equals(authorizedVocabulary.getUri())
+        ).when(vocabularyAuthorizationService).canRead(any(Vocabulary.class));
+
+        Set<TermInfoWithParents> terms = new HashSet<>(Set.of(term));
+
+        sut.removeUnauthorizedTermsAndAncestors(terms);
+
+        assertEquals(1, terms.size());
+        assertTrue(terms.contains(term));
+        assertEquals(1, term.getParentTerms().size());
+        assertTrue(term.getParentTerms().contains(term2));
+        assertTrue(term2.getParentTerms().isEmpty());
     }
 }

--- a/src/test/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/security/authorization/TermAuthorizationServiceTest.java
@@ -26,8 +26,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -88,5 +93,36 @@ class TermAuthorizationServiceTest {
 
         assertTrue(sut.canRemove(term));
         verify(vocabularyAuthorizationService).canRemove(v);
+    }
+
+    @Test
+    void canReadTermCollectionChecksIfUserCanReadTermVocabularies() {
+        when(vocabularyAuthorizationService.canRead(any(Vocabulary.class))).thenReturn(true);
+        final Term term = Generator.generateTermWithId();
+        final Term term2 = Generator.generateTermWithId();
+        final Vocabulary v = Generator.generateVocabularyWithId();
+        final Vocabulary v2 = Generator.generateVocabularyWithId();
+        term.setVocabulary(v.getUri());
+        term2.setVocabulary(v2.getUri());
+
+        assertTrue(sut.canRead(Set.of(term, term2)));
+        verify(vocabularyAuthorizationService).canRead(v);
+    }
+
+    @Test
+    void canReadTermCollectionReturnsFalseIfUserCannotReadTermVocabularies() {
+        final Term term = Generator.generateTermWithId();
+        final Term term2 = Generator.generateTermWithId();
+        final Vocabulary v = Generator.generateVocabularyWithId();
+        final Vocabulary v2 = Generator.generateVocabularyWithId();
+        term.setVocabulary(v.getUri());
+        term2.setVocabulary(v2.getUri());
+
+        // lenient because of the process order is unknown and hence this stub may be unnecessary in some executions
+        lenient().when(vocabularyAuthorizationService.canRead(v)).thenReturn(true);
+        when(vocabularyAuthorizationService.canRead(v2)).thenReturn(false);
+
+        assertFalse(sut.canRead(Set.of(term, term2)));
+        verify(vocabularyAuthorizationService, atLeastOnce()).canRead(any(Vocabulary.class));
     }
 }


### PR DESCRIPTION
Enhancement #418

Introduces `FullTermDtoWithAncestors` which enhances `Term` with parent representation capable of referencing full ancestor chain.  
I did not find a way to have a common ancestor for `TermInfo` and `TermInfoWithParents` without JOPA prioritizing `TermInfoWithParents` since it is a [more specific type](https://github.com/kbss-cvut/jopa/issues/1).

Changes the type of parent terms field in `ReadOnlyTerm` from `TermInfo` to the new `TermDescription` interface, allowing switching between implementations with and without parents.
`ReadOnlyTerm` is not used when loading data with the entity manager.
Data are only being mapped to it later, so the change to the abstraction was possible.

Added new query option `loadAllAncestors` to term detail endpoints, allowing to request the full ancestor chain.
