### PR TITLE
[Bug] Fix FTS not matching certain queries in Czech language

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/SearchDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/SearchDao.java
@@ -95,15 +95,75 @@ public class SearchDao {
             return searchString;
         }
         final String[] split = searchString.trim().split("\\s+");
-        final int lastIdx = split.length - 1;
-        if (split[lastIdx].length() >= WILDCARD_MIN_LENGTH) {
-            split[lastIdx] = split[lastIdx] + LUCENE_WILDCARD;
-        }
+
         // Require every token (AND) to avoid huge OR candidate sets that are expensive to rank
         for (int i = 0; i < split.length; i++) {
             split[i] = "+" + split[i];
         }
+
+        final int lastIdx = split.length - 1;
+        // -1 to compensate prepended '+'
+        if (split[lastIdx].length() - 1 >= WILDCARD_MIN_LENGTH) {
+            return joinLuceneQueryWithWildcard(split, searchString.length() + split.length);
+        }
         return String.join(" ", split);
+    }
+
+    /**
+     * Appends string following format {@code (token) OR (token*)} to the {@code builder}.
+     * <p>
+     * {@code (token)} allows Lucene to perform text operations (e.g. use <a href="https://lucene.apache.org/core/9_4_2/analysis/common/org/apache/lucene/analysis/cz/CzechStemmer.html">Stemmer</a>)
+     * <p>
+     * {@code (token*)} instruct Lucene to perform simple prefix matching on index entries
+     *
+     * @param token token to use
+     * @param builder String builder to which the query should be appended
+     * @return the {@code builder}
+     */
+    private static StringBuilder buildLuceneQueryWithWildcard(String token, StringBuilder builder) {
+        return builder
+                .append('(')
+                .append(token)
+                .append(") OR (")
+                .append(token)
+                .append(LUCENE_WILDCARD)
+                .append(')');
+    }
+
+    /**
+     * Joins the given tokens into a Lucene query following format
+     * {@code (tokens-1) AND ((lastToken) OR (lastToken*))}
+     *
+     * @param tokens tokens from which query should be constructed
+     * @param totalLength the total length of all strings in the {@code tokens} array
+     * @return constructed query
+     */
+    static String joinLuceneQueryWithWildcard(String[] tokens, int totalLength) {
+        int lastIndex = tokens.length - 1;
+        int lastTokenLength = tokens[lastIndex].length();
+
+        // totalLength = every token is appended
+        // lastTokenLength = the last token is appended once more
+        // "() AND (() OR (*))".length = 18
+        int additionalCharCount = "() OR (*)".length() + (tokens.length - 1) * "() AND ()".length();
+        StringBuilder builder = new StringBuilder(totalLength + lastTokenLength + additionalCharCount);
+
+        if (tokens.length == 1) {
+            return buildLuceneQueryWithWildcard(tokens[0], builder).toString();
+        }
+
+        builder.append('(');
+        for (int i = 0; i < lastIndex; i++) {
+            builder.append(tokens[i]).append(' ');
+        }
+        builder.append(") AND ((")
+                       .append(tokens[lastIndex])
+                       .append(") OR (")
+                       .append(tokens[lastIndex])
+                       .append(LUCENE_WILDCARD)
+                       .append("))");
+
+        return builder.toString();
     }
 
     private static String splitExactMatch(String searchString) {

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/SearchDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/SearchDao.java
@@ -144,9 +144,7 @@ public class SearchDao {
 
         // totalLength = every token is appended
         // lastTokenLength = the last token is appended once more
-        // "() AND (() OR (*))".length = 18
-        int additionalCharCount = "() OR (*)".length() + (tokens.length - 1) * "() AND ()".length();
-        StringBuilder builder = new StringBuilder(totalLength + lastTokenLength + additionalCharCount);
+        StringBuilder builder = new StringBuilder(totalLength + lastTokenLength);
 
         if (tokens.length == 1) {
             return buildLuceneQueryWithWildcard(tokens[0], builder).toString();

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
@@ -96,7 +96,7 @@ class SearchDaoTest {
         final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(ftsQueryMock, atLeastOnce()).setParameter(anyString(), captor.capture(), any());
         final Optional<String> argument = captor.getAllValues().stream()
-                                                .filter(s -> s.equals("+" + searchString + SearchDao.LUCENE_WILDCARD))
+                                                .filter(s -> s.contains("+" + searchString + SearchDao.LUCENE_WILDCARD))
                                                 .findAny();
         assertTrue(argument.isPresent());
     }
@@ -110,7 +110,8 @@ class SearchDaoTest {
         final ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(ftsQueryMock, atLeastOnce()).setParameter(anyString(), captor.capture(), any());
         final Optional<String> argument = captor.getAllValues().stream()
-                                                .filter(s -> s.equals("+termOne +termTwo +" + lastToken + SearchDao.LUCENE_WILDCARD))
+                                                .filter(s -> s.contains("+termOne +termTwo"))
+                                                .filter(s -> s.contains('+' + lastToken + SearchDao.LUCENE_WILDCARD))
                                                 .findAny();
         assertTrue(argument.isPresent());
     }

--- a/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/persistence/dao/SearchDaoTest.java
@@ -174,4 +174,23 @@ class SearchDaoTest {
                                                              Constants.DEFAULT_PAGE_SPEC, List.of());
         assertEquals(13, result.getTotalElements());
     }
+
+    @Test
+    void joinLuceneQueryWithWildcardMatchesTheExpectedPatternForSingleItemArray() {
+        final String[] tokens = new String[]{"+slovo"};
+
+        final String result = SearchDao.joinLuceneQueryWithWildcard(tokens, tokens[0].length());
+
+        assertEquals("(+slovo) OR (+slovo*)", result);
+    }
+
+    @Test
+    void joinLuceneQueryWithWildcardMatchesTheExpectedPatternForMultipleItemArray() {
+        final String[] tokens = new String[]{"+afrikán", "+slunečnice", "+růže"};
+        final int totalLength = String.join("", tokens).length();
+
+        final String result = SearchDao.joinLuceneQueryWithWildcard(tokens, totalLength);
+
+        assertEquals("(+afrikán +slunečnice ) AND ((+růže) OR (+růže*))", result);
+    }
 }


### PR DESCRIPTION
kbss-cvut/termit-ui#835

Word `lokalita` is indexed by Lucene after processing (stemming) as `lokalit`  
Wildcard query `term*` instructs Lucene to perform prefix matching on indexed terms. There is no further processing of the queried term. The prefix is being matched as specified by the query.

The query `lokalit*` yields results as expected because the query matches indexed terms with the given prefix.
The query `lokalita*` yields no results because there is simply no indexed term with the given prefix.

This PR updates the Lucene query construction to use the format `(+term) OR (+term*)`.
`+term` allows Lucene to perform its text processing
`+term*` keeps the prefix matching  

When there are multiple terms, the query is constructed as `(+a +b +c) AND ((+term) OR (+term*))`
