### PR TITLE
[Enhancement] Update getAll terms endpoint to support includeTerms when retrieving flat list

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/dto/listing/FlatTermDto.java
+++ b/src/main/java/cz/cvut/kbss/termit/dto/listing/FlatTermDto.java
@@ -26,6 +26,7 @@ import cz.cvut.kbss.termit.model.Term;
 import cz.cvut.kbss.termit.model.util.HasIdentifier;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -38,11 +39,19 @@ public class FlatTermDto extends AbstractTerm {
     public FlatTermDto() {}
 
     public FlatTermDto(Term other) {
+        this(other, other.getParentTerms());
+    }
+
+    public FlatTermDto(TermDto dto) {
+        this(dto, dto.getParentTerms());
+    }
+
+    public FlatTermDto(AbstractTerm other, Collection<? extends HasIdentifier> parents) {
         super(other);
-        if (other.getParentTerms() != null) {
-            setParentTerms(other.getParentTerms().stream()
-                .map(HasIdentifier::getUri)
-                .collect(Collectors.toSet()));
+        if (parents != null) {
+            setParentTerms(parents.stream()
+                                  .map(HasIdentifier::getUri)
+                                  .collect(Collectors.toSet()));
         }
     }
 

--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/TermDao.java
@@ -424,6 +424,27 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
     }
 
     /**
+     * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy and returns them
+     * as a flat list of DTOs.
+     *
+     * @param vocabulary Vocabulary whose terms to retrieve. A reference is sufficient
+     * @param pageSpec   Page specification
+     * @param includeTerms Identifier of terms that should be additionally included in the result
+     * @return Flat list of vocabulary term DTOs
+     * @see #findAllFlat(Pageable, Collection)
+     */
+    public List<FlatTermDto> findAllFlat(Vocabulary vocabulary, Pageable pageSpec, Collection<URI> includeTerms) {
+        Objects.requireNonNull(vocabulary);
+        try {
+            final List<FlatTermDto> result =  findAllFlatQuery(vocabulary, pageSpec).getResultList();
+            loadIncludedTerms(includeTerms).forEach(dto -> result.add(new FlatTermDto(dto)));
+            return result;
+        } catch (RuntimeException e) {
+            throw new PersistenceException(e);
+        }
+    }
+
+    /**
      * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy. Filters terms
      * that have label and definition in the instance language.
      * <p>
@@ -1040,6 +1061,27 @@ public class TermDao extends BaseAssetDao<Term> implements SnapshotProvider<Term
         } catch (RuntimeException e) {
             throw new PersistenceException(e);
         }
+    }
+
+
+    /**
+     * Finds all terms contained in any of the specified vocabularies and returns them as a flat list of DTOs.
+     * <p>
+     * Returns terms as a list of {@link FlatTermDto} instances, i.e., only referencing direct parent terms.
+     *
+     * @param vocabularies Identifiers of vocabularies whose terms should be returned
+     * @param pageSpec     Page specification
+     * @param includeTerms Identifier of terms that should be additionally included in the result
+     * @return Flat list of matching terms
+     * @see #findAllFlatInVocabularies(String, Collection, Pageable)
+     */
+    public List<FlatTermDto> findAllFlatInVocabularies(Collection<URI> vocabularies,
+                                                       Pageable pageSpec, Collection<URI> includeTerms) {
+        List<FlatTermDto> result = findAllFlatInVocabularies(vocabularies, pageSpec);
+        if (includeTerms != null && !includeTerms.isEmpty()) {
+            loadIncludedTerms(includeTerms).forEach(dto -> result.add(new FlatTermDto(dto)));
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -20,6 +20,7 @@ package cz.cvut.kbss.termit.rest;
 import cz.cvut.kbss.jsonld.JsonLd;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
+import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.model.Term;
@@ -176,6 +177,35 @@ public class TermController extends BaseController {
                                                          new TermSelectionParams(flat, full, includeImported, includeRelated,
                                                                                  createPageRequest(pageSize, pageNo))));
         });
+    }
+
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
+               description = "Gets flattened list of terms from the vocabulary with the specified identifier.")
+    @ApiResponse(responseCode = "200", description = "Flat list of vocabulary terms.")
+    @GetMapping(value = "/vocabularies/{localName}/terms/flat",
+                produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
+    public List<FlatTermDto> getAllFlat(
+            @Parameter(description = ApiDoc.ID_LOCAL_NAME_DESCRIPTION, example = ApiDoc.ID_LOCAL_NAME_EXAMPLE)
+            @PathVariable String localName,
+            @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
+            @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
+            @Parameter(description = "Whether to include terms from imported vocabularies.")
+            @RequestParam(name = "includeImported", required = false) boolean includeImported,
+            @Parameter(description = "Whether to include terms from related vocabularies.")
+            @RequestParam(name = "includeRelated", required = false) boolean includeRelated,
+            @Parameter(
+                    description = "Identifiers of terms that should be included in the response (regardless of whether they are root terms or not).")
+            @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
+            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
+            @RequestParam(name = QueryParams.PAGE_SIZE, required = false) Integer pageSize,
+            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
+            @RequestParam(name = QueryParams.PAGE, required = false) Integer pageNo
+    ) {
+        final URI vocabularyUri = getVocabularyUri(namespace, localName);
+        final Vocabulary vocabulary = getVocabulary(vocabularyUri);
+        final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
+                createPageRequest(pageSize, pageNo));
+        return termService.findAllFlat(vocabulary, includeTerms, params);
     }
 
     private Optional<ResponseEntity<?>> exportTerms(Vocabulary vocabulary, ExportType exportType,

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -20,7 +20,6 @@ package cz.cvut.kbss.termit.rest;
 import cz.cvut.kbss.jsonld.JsonLd;
 import cz.cvut.kbss.termit.dto.TermInfo;
 import cz.cvut.kbss.termit.dto.filter.ChangeRecordFilterDto;
-import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.exception.TermItException;
 import cz.cvut.kbss.termit.model.Term;
@@ -159,6 +158,9 @@ public class TermController extends BaseController {
             @RequestParam(name = "flat", required = false, defaultValue = "false") boolean flat,
             @Parameter(description = "Boolean flag to determine whether to return full versions of the terms.")
             @RequestParam(name = "full", required = false, defaultValue = "false") boolean full,
+            @Parameter(
+                    description = "Identifiers of terms that should be included in the flat list response (regardless of whether they are root terms or not).")
+            @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
             @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
             @RequestParam(name = QueryParams.PAGE_SIZE, required = false) Integer pageSize,
             @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
@@ -170,6 +172,13 @@ public class TermController extends BaseController {
                                                          new TermSelectionParams(flat, full, includeImported, includeRelated,
                                                                                  createPageRequest(pageSize, pageNo))));
         }
+
+        if (flat && includeTerms != null && !includeTerms.isEmpty()) {
+            final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
+                    createPageRequest(pageSize, pageNo));
+            return ResponseEntity.ok(termService.findAllFlat(vocabulary, includeTerms, params));
+        }
+
         final Optional<ResponseEntity<?>> export = exportTerms(vocabulary, exportType, properties, acceptType);
         return export.orElseGet(() -> {
             verifyAcceptType(acceptType);
@@ -177,35 +186,6 @@ public class TermController extends BaseController {
                                                          new TermSelectionParams(flat, full, includeImported, includeRelated,
                                                                                  createPageRequest(pageSize, pageNo))));
         });
-    }
-
-    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
-               description = "Gets flattened list of terms from the vocabulary with the specified identifier.")
-    @ApiResponse(responseCode = "200", description = "Flat list of vocabulary terms.")
-    @GetMapping(value = "/vocabularies/{localName}/terms/flat",
-                produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
-    public List<FlatTermDto> getAllFlat(
-            @Parameter(description = ApiDoc.ID_LOCAL_NAME_DESCRIPTION, example = ApiDoc.ID_LOCAL_NAME_EXAMPLE)
-            @PathVariable String localName,
-            @Parameter(description = ApiDoc.ID_NAMESPACE_DESCRIPTION, example = ApiDoc.ID_NAMESPACE_EXAMPLE)
-            @RequestParam(name = QueryParams.NAMESPACE, required = false) Optional<String> namespace,
-            @Parameter(description = "Whether to include terms from imported vocabularies.")
-            @RequestParam(name = "includeImported", required = false) boolean includeImported,
-            @Parameter(description = "Whether to include terms from related vocabularies.")
-            @RequestParam(name = "includeRelated", required = false) boolean includeRelated,
-            @Parameter(
-                    description = "Identifiers of terms that should be included in the response (regardless of whether they are root terms or not).")
-            @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
-            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
-            @RequestParam(name = QueryParams.PAGE_SIZE, required = false) Integer pageSize,
-            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
-            @RequestParam(name = QueryParams.PAGE, required = false) Integer pageNo
-    ) {
-        final URI vocabularyUri = getVocabularyUri(namespace, localName);
-        final Vocabulary vocabulary = getVocabulary(vocabularyUri);
-        final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
-                createPageRequest(pageSize, pageNo));
-        return termService.findAllFlat(vocabulary, includeTerms, params);
     }
 
     private Optional<ResponseEntity<?>> exportTerms(Vocabulary vocabulary, ExportType exportType,

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -174,7 +174,7 @@ public class TermController extends BaseController {
                                                                                  createPageRequest(pageSize, pageNo))));
         }
 
-        if (flat && includeTerms != null && !includeTerms.isEmpty()) {
+        if (flat && !includeTerms.isEmpty()) {
             final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
                     createPageRequest(pageSize, pageNo));
             return ResponseEntity.ok(termService.findAllFlat(vocabulary, includeTerms, params));

--- a/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/TermController.java
@@ -159,7 +159,8 @@ public class TermController extends BaseController {
             @Parameter(description = "Boolean flag to determine whether to return full versions of the terms.")
             @RequestParam(name = "full", required = false, defaultValue = "false") boolean full,
             @Parameter(
-                    description = "Identifiers of terms that should be included in the flat list response (regardless of whether they are root terms or not).")
+                    description = "Identifiers of terms that should be included in the flat list response " +
+                            "(regardless of whether they are root terms or not).")
             @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
             @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
             @RequestParam(name = QueryParams.PAGE_SIZE, required = false) Integer pageSize,

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -19,7 +19,6 @@ package cz.cvut.kbss.termit.rest.readonly;
 
 import cz.cvut.kbss.jsonld.JsonLd;
 import cz.cvut.kbss.termit.dto.TermInfo;
-import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.readonly.ReadOnlyTerm;
 import cz.cvut.kbss.termit.model.Vocabulary;
@@ -97,6 +96,9 @@ public class ReadOnlyTermController extends BaseController {
                             @RequestParam(name = "includeRelated", required = false) boolean includeRelated,
                             @Parameter(description = "Boolean flag to determine whether the list should be flattened.")
                             @RequestParam(name = "flat", required = false, defaultValue = "false") boolean flat,
+                            @Parameter(description = "Identifiers of terms that should be included in the flat list response " +
+                                    "(regardless of whether they are root terms or not).")
+                            @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
                             @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
                             @RequestParam(name = Constants.QueryParams.PAGE_SIZE, required = false) Integer pageSize,
                             @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
@@ -106,38 +108,17 @@ public class ReadOnlyTermController extends BaseController {
             return termService.findAll(searchString, vocabulary, new TermSelectionParams(flat, false, includeImported, includeRelated,
                                                                                          createPageRequest(pageSize,
                                                                                                            pageNo)));
-        } else {
-            return termService.findAll(vocabulary, new TermSelectionParams(flat, false, includeImported, includeRelated,
-                                                                           createPageRequest(pageSize, pageNo)));
         }
-    }
 
-    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
-               description = "Gets flattened list of terms from the vocabulary with the specified identifier.")
-    @ApiResponse(responseCode = "200", description = "Flat list of vocabulary terms.")
-    @GetMapping(value = "/vocabularies/{localName}/terms/flat",
-                produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
-    public List<FlatTermDto> getAllFlat(
-            @Parameter(description = TermController.ApiDoc.ID_LOCAL_NAME_DESCRIPTION, example = TermController.ApiDoc.ID_LOCAL_NAME_EXAMPLE)
-            @PathVariable String localName,
-            @Parameter(description = TermController.ApiDoc.ID_NAMESPACE_DESCRIPTION, example = TermController.ApiDoc.ID_NAMESPACE_EXAMPLE)
-            @RequestParam(name = Constants.QueryParams.NAMESPACE, required = false) Optional<String> namespace,
-            @Parameter(description = "Whether to include terms from imported vocabularies.")
-            @RequestParam(name = "includeImported", required = false) boolean includeImported,
-            @Parameter(description = "Whether to include terms from related vocabularies.")
-            @RequestParam(name = "includeRelated", required = false) boolean includeRelated,
-            @Parameter(
-                    description = "Identifiers of terms that should be included in the response (regardless of whether they are root terms or not).")
-            @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
-            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
-            @RequestParam(name = Constants.QueryParams.PAGE_SIZE, required = false) Integer pageSize,
-            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
-            @RequestParam(name = Constants.QueryParams.PAGE, required = false) Integer pageNo
-    ) {
-        final Vocabulary vocabulary = getVocabulary(localName, namespace);
-        final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
-                createPageRequest(pageSize, pageNo));
-        return termService.findAllFlat(vocabulary, includeTerms, params);
+        if (flat && includeTerms != null && !includeTerms.isEmpty()) {
+            final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
+                    createPageRequest(pageSize, pageNo));
+            return termService.findAllFlat(vocabulary, includeTerms, params);
+        }
+
+        return termService.findAll(vocabulary, new TermSelectionParams(flat, false, includeImported, includeRelated,
+                                                                       createPageRequest(pageSize, pageNo)));
+
     }
 
     private Vocabulary getVocabulary(String fragment, Optional<String> namespace) {

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -19,6 +19,7 @@ package cz.cvut.kbss.termit.rest.readonly;
 
 import cz.cvut.kbss.jsonld.JsonLd;
 import cz.cvut.kbss.termit.dto.TermInfo;
+import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.readonly.ReadOnlyTerm;
 import cz.cvut.kbss.termit.model.Vocabulary;
@@ -109,6 +110,34 @@ public class ReadOnlyTermController extends BaseController {
             return termService.findAll(vocabulary, new TermSelectionParams(flat, false, includeImported, includeRelated,
                                                                            createPageRequest(pageSize, pageNo)));
         }
+    }
+
+    @Operation(security = {@SecurityRequirement(name = "bearer-key")},
+               description = "Gets flattened list of terms from the vocabulary with the specified identifier.")
+    @ApiResponse(responseCode = "200", description = "Flat list of vocabulary terms.")
+    @GetMapping(value = "/vocabularies/{localName}/terms/flat",
+                produces = {MediaType.APPLICATION_JSON_VALUE, JsonLd.MEDIA_TYPE})
+    public List<FlatTermDto> getAllFlat(
+            @Parameter(description = TermController.ApiDoc.ID_LOCAL_NAME_DESCRIPTION, example = TermController.ApiDoc.ID_LOCAL_NAME_EXAMPLE)
+            @PathVariable String localName,
+            @Parameter(description = TermController.ApiDoc.ID_NAMESPACE_DESCRIPTION, example = TermController.ApiDoc.ID_NAMESPACE_EXAMPLE)
+            @RequestParam(name = Constants.QueryParams.NAMESPACE, required = false) Optional<String> namespace,
+            @Parameter(description = "Whether to include terms from imported vocabularies.")
+            @RequestParam(name = "includeImported", required = false) boolean includeImported,
+            @Parameter(description = "Whether to include terms from related vocabularies.")
+            @RequestParam(name = "includeRelated", required = false) boolean includeRelated,
+            @Parameter(
+                    description = "Identifiers of terms that should be included in the response (regardless of whether they are root terms or not).")
+            @RequestParam(name = "includeTerms", required = false, defaultValue = "") List<URI> includeTerms,
+            @Parameter(description = ApiDocConstants.PAGE_SIZE_DESCRIPTION)
+            @RequestParam(name = Constants.QueryParams.PAGE_SIZE, required = false) Integer pageSize,
+            @Parameter(description = ApiDocConstants.PAGE_NO_DESCRIPTION)
+            @RequestParam(name = Constants.QueryParams.PAGE, required = false) Integer pageNo
+    ) {
+        final Vocabulary vocabulary = getVocabulary(localName, namespace);
+        final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
+                createPageRequest(pageSize, pageNo));
+        return termService.findAllFlat(vocabulary, includeTerms, params);
     }
 
     private Vocabulary getVocabulary(String fragment, Optional<String> namespace) {

--- a/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
+++ b/src/main/java/cz/cvut/kbss/termit/rest/readonly/ReadOnlyTermController.java
@@ -110,7 +110,7 @@ public class ReadOnlyTermController extends BaseController {
                                                                                                            pageNo)));
         }
 
-        if (flat && includeTerms != null && !includeTerms.isEmpty()) {
+        if (flat && !includeTerms.isEmpty()) {
             final TermSelectionParams params = new TermSelectionParams(true, false, includeImported, includeRelated,
                     createPageRequest(pageSize, pageNo));
             return termService.findAllFlat(vocabulary, includeTerms, params);

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -767,7 +767,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      * @param selectionParams term search parameters
      * @return flattened list of terms
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<FlatTermDto> findAllFlat(Vocabulary vocabulary, List<URI> includeTerms, TermSelectionParams selectionParams) {
         if (selectionParams.full()) {
             throw new IllegalArgumentException("Full term representation is not supported");

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -158,7 +158,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      * @param selectionParams Term selection parameters
      * @return Matching terms
      */
-    @Transactional
+    @Transactional(readOnly = true)
     public List<? extends AbstractTerm> findAll(Vocabulary vocabulary, TermSelectionParams selectionParams) {
         Objects.requireNonNull(vocabulary);
         Objects.requireNonNull(selectionParams);

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -158,6 +158,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      * @param selectionParams Term selection parameters
      * @return Matching terms
      */
+    @Transactional
     public List<? extends AbstractTerm> findAll(Vocabulary vocabulary, TermSelectionParams selectionParams) {
         Objects.requireNonNull(vocabulary);
         Objects.requireNonNull(selectionParams);
@@ -766,6 +767,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      * @param selectionParams term search parameters
      * @return flattened list of terms
      */
+    @Transactional
     public List<FlatTermDto> findAllFlat(Vocabulary vocabulary, List<URI> includeTerms, TermSelectionParams selectionParams) {
         if (selectionParams.full()) {
             throw new IllegalArgumentException("Full term representation is not supported");

--- a/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/TermService.java
@@ -167,11 +167,7 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
         } else {
             final boolean includeFromOther = selectionParams.includeImported() || selectionParams.includeRelated();
             if (selectionParams.flat()) {
-                if (includeFromOther) {
-                    final var vocabularies = resolveTargetVocabularies(vocabulary, selectionParams);
-                    return repositoryService.findAllFlatInVocabularies(vocabularies, selectionParams.pageSpec());
-                }
-                return repositoryService.findAllFlat(vocabulary, selectionParams.pageSpec());
+                return findAllFlat(vocabulary, List.of(), selectionParams);
             } else {
                 if (includeFromOther) {
                     final var vocabularies = resolveTargetVocabularies(vocabulary, selectionParams);
@@ -760,5 +756,24 @@ public class TermService implements RudService<Term>, ChangeRecordProvider<Term>
      */
     public boolean exists(URI termId) {
         return repositoryService.exists(termId);
+    }
+
+    /**
+     * Finds all terms from the given vocabulary.
+     *
+     * @param vocabulary the vocabulary from which terms should be returned
+     * @param includeTerms terms that should always be included in the result, no matter on which page
+     * @param selectionParams term search parameters
+     * @return flattened list of terms
+     */
+    public List<FlatTermDto> findAllFlat(Vocabulary vocabulary, List<URI> includeTerms, TermSelectionParams selectionParams) {
+        if (selectionParams.full()) {
+            throw new IllegalArgumentException("Full term representation is not supported");
+        }
+        if (selectionParams.includeImported() || selectionParams.includeRelated()) {
+            final var vocabularies = resolveTargetVocabularies(vocabulary, selectionParams);
+            return repositoryService.findAllFlatInVocabularies(vocabularies, selectionParams.pageSpec(), includeTerms);
+        }
+        return repositoryService.findAllFlat(vocabulary, selectionParams.pageSpec(), includeTerms);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/business/readonly/ReadOnlyTermService.java
@@ -19,6 +19,7 @@ package cz.cvut.kbss.termit.service.business.readonly;
 
 import cz.cvut.kbss.termit.dto.Snapshot;
 import cz.cvut.kbss.termit.dto.TermInfo;
+import cz.cvut.kbss.termit.dto.listing.FlatTermDto;
 import cz.cvut.kbss.termit.dto.listing.TermDto;
 import cz.cvut.kbss.termit.dto.readonly.ReadOnlyTerm;
 import cz.cvut.kbss.termit.model.AbstractTerm;
@@ -184,5 +185,17 @@ public class ReadOnlyTermService {
                                                      .stream().map(HasIdentifier::getUri).collect(Collectors.toSet());
         final Set<TermInfoWithParents> ancestors = termService.findWithAllAncestors(directParentIdentifiers);
         roTerm.setParentTerms(Collections.unmodifiableSet(ancestors));
+    }
+
+    /**
+     * Finds all terms from the given vocabulary.
+     *
+     * @param vocabulary the vocabulary from which terms should be returned
+     * @param includeTerms terms that should always be included in the result, no matter on which page
+     * @param selectionParams term search parameters
+     * @return flattened list of terms
+     */
+    public List<FlatTermDto> findAllFlat(Vocabulary vocabulary, List<URI> includeTerms, TermSelectionParams selectionParams) {
+        return termService.findAllFlat(vocabulary, includeTerms, selectionParams);
     }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/TermRepositoryService.java
@@ -316,6 +316,23 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
     }
 
     /**
+     * Gets all terms from vocabulary, regardless of their position in the term hierarchy and returns them in a flat
+     * structure.
+     * <p>
+     * This returns all terms contained in vocabulary's glossary.
+     *
+     * @param vocabulary Vocabulary whose terms should be returned. A reference is sufficient
+     * @param pageSpec   Page specifying result number and position
+     * @return List of term DTOs ordered by label in a flat structure
+     * @param includeTerms Identifier of terms that should be additionally included in the result
+     * @see #findAllFlat(Vocabulary, Pageable)
+     */
+    @Transactional(readOnly = true)
+    public List<FlatTermDto> findAllFlat(Vocabulary vocabulary, Pageable pageSpec, Collection<URI> includeTerms) {
+        return termDao.findAllFlat(vocabulary, pageSpec, includeTerms);
+    }
+
+    /**
      * Finds all terms in the specified vocabulary, regardless of their position in the term hierarchy. Filters terms
      * that have label and definition in the instance language.
      * <p>
@@ -502,6 +519,20 @@ public class TermRepositoryService extends BaseAssetRepositoryService<Term, Term
     @Transactional(readOnly = true)
     public List<FlatTermDto> findAllFlatInVocabularies(Collection<URI> vocabularies, Pageable pageSpec) {
         return termDao.findAllFlatInVocabularies(vocabularies, pageSpec);
+    }
+
+    /**
+     * Finds all terms contained in any of the specified vocabularies and returns them as a flat list of DTOs.
+     * <p>
+     * Returns terms as a list of {@link FlatTermDto} instances, i.e., only referencing direct parent terms.
+     *
+     * @param vocabularies Identifiers of vocabularies whose terms should be returned
+     * @param pageSpec     Page specification
+     * @return Flat list of matching terms
+     */
+    @Transactional(readOnly = true)
+    public List<FlatTermDto> findAllFlatInVocabularies(Collection<URI> vocabularies, Pageable pageSpec, Collection<URI> includeTerms) {
+        return termDao.findAllFlatInVocabularies(vocabularies, pageSpec, includeTerms);
     }
 
     /**

--- a/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/business/TermServiceTest.java
@@ -816,19 +816,19 @@ class TermServiceTest {
                                 repositoryService).findAll(vocabulary, PageRequest.of(5, 10))),
                 Arguments.of(new TermSelectionParams(true, false, false, false, Constants.DEFAULT_PAGE_SPEC),
                         (BiConsumer<TermRepositoryService, Vocabulary>) (repositoryService, vocabulary) -> verify(
-                                repositoryService).findAllFlat(vocabulary, Constants.DEFAULT_PAGE_SPEC)),
+                                repositoryService).findAllFlat(vocabulary, Constants.DEFAULT_PAGE_SPEC, List.of())),
                 Arguments.of(new TermSelectionParams(false, true, false, false, Constants.DEFAULT_PAGE_SPEC),
                         (BiConsumer<TermRepositoryService, Vocabulary>) (repositoryService, vocabulary) -> verify(
                                 repositoryService).findAllFull(vocabulary, Constants.DEFAULT_PAGE_SPEC)),
                 Arguments.of(new TermSelectionParams(true, false, true, false, Constants.DEFAULT_PAGE_SPEC),
                         (BiConsumer<TermRepositoryService, Vocabulary>) (repositoryService, vocabulary) -> verify(
-                                repositoryService).findAllFlatInVocabularies(anyCollection(), eq(Constants.DEFAULT_PAGE_SPEC))),
+                                repositoryService).findAllFlatInVocabularies(anyCollection(), eq(Constants.DEFAULT_PAGE_SPEC), eq(List.of()))),
                 Arguments.of(new TermSelectionParams(false, false, false, true, Constants.DEFAULT_PAGE_SPEC),
                         (BiConsumer<TermRepositoryService, Vocabulary>) (repositoryService, vocabulary) -> verify(
                                 repositoryService).findAllInVocabularies(anyCollection(), eq(Constants.DEFAULT_PAGE_SPEC))),
                 Arguments.of(new TermSelectionParams(true, false, false, true, Constants.DEFAULT_PAGE_SPEC),
                         (BiConsumer<TermRepositoryService, Vocabulary>) (repositoryService, vocabulary) -> verify(
-                                repositoryService).findAllFlatInVocabularies(anyCollection(), eq(Constants.DEFAULT_PAGE_SPEC)))
+                                repositoryService).findAllFlatInVocabularies(anyCollection(), eq(Constants.DEFAULT_PAGE_SPEC), eq(List.of())))
         );
     }
 


### PR DESCRIPTION
kbss-cvut/termit-ui#822

In order to allow the tree select component to scroll the selected term in flat-list mode, the flat list endpoint needs to support loading terms with the `includeTerms` parameter.

Support for the `includeTerms` parameter was only added for flat list representation.