### PR TITLE
[Bug] Evict Jopa cache for imported vocabulary

### DIFF
--- a/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
+++ b/src/main/java/cz/cvut/kbss/termit/persistence/dao/VocabularyDao.java
@@ -594,4 +594,16 @@ public class VocabularyDao extends BaseAssetDao<Vocabulary>
             throw new PersistenceException(e);
         }
     }
+
+    /**
+     * Evicts the context of the given vocabulary from JOPA cache
+     *
+     * @param vocabulary the vocabualry to evict from cache
+     */
+    public void evictCache(Vocabulary vocabulary) {
+        Objects.requireNonNull(vocabulary.getUri());
+        em.flush();
+        em.clear();
+        em.getEntityManagerFactory().getCache().evict(vocabulary.getUri());
+    }
 }

--- a/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
+++ b/src/main/java/cz/cvut/kbss/termit/service/repository/VocabularyRepositoryService.java
@@ -54,6 +54,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.time.Instant;
@@ -220,16 +221,9 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
     @Transactional
     public Vocabulary importVocabulary(boolean rename, MultipartFile file) {
         Objects.requireNonNull(file);
-        try {
-            String contentType = Utils.resolveContentType(file);
-            return importers.importVocabulary(
-                    new VocabularyImporter.ImportConfiguration(rename, null, this::initDocument),
-                    new VocabularyImporter.ImportInput(contentType, file.getInputStream()));
-        } catch (VocabularyImportException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new VocabularyImportException("Unable to import vocabulary. Cause: " + e.getMessage());
-        }
+        return importVocabularyFromFile(
+                new VocabularyImporter.ImportConfiguration(rename, null, this::initDocument),
+                file);
     }
 
     @CacheEvict(allEntries = true, cacheNames = "vocabularies")
@@ -237,16 +231,9 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
     public Vocabulary importVocabulary(URI vocabularyIri, MultipartFile file) {
         Objects.requireNonNull(vocabularyIri);
         Objects.requireNonNull(file);
-        try {
-            String contentType = Utils.resolveContentType(file);
-            return importers.importVocabulary(
-                    new VocabularyImporter.ImportConfiguration(false, vocabularyIri, this::initDocument),
-                    new VocabularyImporter.ImportInput(contentType, file.getInputStream()));
-        } catch (VocabularyImportException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new VocabularyImportException("Unable to import vocabulary. Cause: " + e.getMessage(), e);
-        }
+        return importVocabularyFromFile(
+                new VocabularyImporter.ImportConfiguration(false, vocabularyIri, this::initDocument),
+                file);
     }
 
     @CacheEvict(allEntries = true, cacheNames = "vocabularies")
@@ -254,10 +241,36 @@ public class VocabularyRepositoryService extends BaseAssetRepositoryService<Voca
     public Vocabulary importVocabulary(URI vocabularyIri, String contentType, InputStream inputStream) {
         Objects.requireNonNull(vocabularyIri);
         Objects.requireNonNull(inputStream);
+        return importVocabulary(
+                new VocabularyImporter.ImportConfiguration(false, vocabularyIri, this::initDocument),
+                new VocabularyImporter.ImportInput(contentType, inputStream));
+    }
+
+    private Vocabulary importVocabularyFromFile(VocabularyImporter.ImportConfiguration configuration, MultipartFile file) {
         try {
-            return importers.importVocabulary(
-                    new VocabularyImporter.ImportConfiguration(false, vocabularyIri, this::initDocument),
-                    new VocabularyImporter.ImportInput(contentType, inputStream));
+            String contentType = Utils.resolveContentType(file);
+            return importVocabulary(
+                    configuration,
+                    new VocabularyImporter.ImportInput(contentType, file.getInputStream()));
+        } catch (IOException e) {
+            throw new VocabularyImportException("Unable to import vocabulary. Cause: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Imports the vocabulary with the given configuration and input and evicts JOPA cache for the imported vocabualry.
+     *
+     * @param configuration the import configuration
+     * @param input the import config
+     * @see #importers#importVocabulary(VocabularyImporter.ImportConfiguration, VocabularyImporter.ImportInput)
+     * @return The imported vocabualry
+     */
+    private Vocabulary importVocabulary(VocabularyImporter.ImportConfiguration configuration, VocabularyImporter.ImportInput input) {
+        try {
+            final Vocabulary imported = importers.importVocabulary(configuration, input);
+            vocabularyDao.evictCache(imported);
+            // refresh the imported vocabulary from database after evicted cache
+            return findRequired(imported.getUri());
         } catch (VocabularyImportException e) {
             throw e;
         } catch (Exception e) {

--- a/src/test/java/cz/cvut/kbss/termit/service/VocabularyRepositoryServiceImportTest.java
+++ b/src/test/java/cz/cvut/kbss/termit/service/VocabularyRepositoryServiceImportTest.java
@@ -20,6 +20,7 @@ package cz.cvut.kbss.termit.service;
 import cz.cvut.kbss.termit.environment.Environment;
 import cz.cvut.kbss.termit.environment.Generator;
 import cz.cvut.kbss.termit.model.Vocabulary;
+import cz.cvut.kbss.termit.persistence.dao.VocabularyDao;
 import cz.cvut.kbss.termit.service.importer.VocabularyImporter;
 import cz.cvut.kbss.termit.service.importer.VocabularyImporters;
 import cz.cvut.kbss.termit.service.repository.VocabularyRepositoryService;
@@ -35,6 +36,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -49,6 +51,9 @@ class VocabularyRepositoryServiceImportTest {
     @Mock
     private VocabularyImporters importer;
 
+    @Mock
+    private VocabularyDao dao;
+
     @InjectMocks
     private VocabularyRepositoryService sut;
 
@@ -60,6 +65,7 @@ class VocabularyRepositoryServiceImportTest {
         final Vocabulary vocabulary = Generator.generateVocabularyWithId();
         when(importer.importVocabulary(any(VocabularyImporter.ImportConfiguration.class),
                                        any(VocabularyImporter.ImportInput.class))).thenReturn(vocabulary);
+        when(dao.find(vocabulary.getUri())).thenReturn(Optional.of(vocabulary));
         final Vocabulary result = sut.importVocabulary(vocabulary.getUri(), input);
         final ArgumentCaptor<VocabularyImporter.ImportInput> captor = ArgumentCaptor.forClass(
                 VocabularyImporter.ImportInput.class);


### PR DESCRIPTION
When a vocabulary is imported, the importer may return an incomplete object (e.g., with missing root terms). 
Furthermore, when an existing vocabulary is being replaced, the old managed object could be cached by Jopa.

Changes - on each Vocabulary import:
- clear entity manager
- evict entity manager cache for the vocabulary context
- always return a fresh Vocabulary object from the repository

